### PR TITLE
:sparkles: Implemented the Workflow Status service.

### DIFF
--- a/jira/internal/workflow_impl.go
+++ b/jira/internal/workflow_impl.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 )
 
-func NewWorkflowService(client service.Client, version string, scheme *WorkflowSchemeService) (*WorkflowService, error) {
+func NewWorkflowService(client service.Client, version string, scheme *WorkflowSchemeService, status *WorkflowStatusService) (*WorkflowService, error) {
 
 	if version == "" {
 		return nil, model.ErrNoVersionProvided
@@ -21,12 +21,14 @@ func NewWorkflowService(client service.Client, version string, scheme *WorkflowS
 	return &WorkflowService{
 		internalClient: &internalWorkflowImpl{c: client, version: version},
 		Scheme:         scheme,
+		Status:         status,
 	}, nil
 }
 
 type WorkflowService struct {
 	internalClient jira.WorkflowConnector
 	Scheme         *WorkflowSchemeService
+	Status         *WorkflowStatusService
 }
 
 // Create creates a workflow.

--- a/jira/internal/workflow_impl_test.go
+++ b/jira/internal/workflow_impl_test.go
@@ -147,7 +147,7 @@ func Test_internalWorkflowImpl_Gets(t *testing.T) {
 				testCase.on(&testCase.fields)
 			}
 
-			newService, err := NewWorkflowService(testCase.fields.c, testCase.fields.version, nil)
+			newService, err := NewWorkflowService(testCase.fields.c, testCase.fields.version, nil, nil)
 			assert.NoError(t, err)
 
 			gotResult, gotResponse, err := newService.Gets(testCase.args.ctx, testCase.args.options, testCase.args.startAt,
@@ -292,7 +292,7 @@ func Test_internalWorkflowImpl_Delete(t *testing.T) {
 				testCase.on(&testCase.fields)
 			}
 
-			newService, err := NewWorkflowService(testCase.fields.c, testCase.fields.version, nil)
+			newService, err := NewWorkflowService(testCase.fields.c, testCase.fields.version, nil, nil)
 			assert.NoError(t, err)
 
 			gotResponse, err := newService.Delete(testCase.args.ctx, testCase.args.workflowId)
@@ -459,7 +459,7 @@ func Test_internalWorkflowImpl_Create(t *testing.T) {
 				testCase.on(&testCase.fields)
 			}
 
-			newService, err := NewWorkflowService(testCase.fields.c, testCase.fields.version, nil)
+			newService, err := NewWorkflowService(testCase.fields.c, testCase.fields.version, nil, nil)
 			assert.NoError(t, err)
 
 			gotResult, gotResponse, err := newService.Create(testCase.args.ctx, testCase.args.payload)

--- a/jira/internal/workflow_status_impl.go
+++ b/jira/internal/workflow_status_impl.go
@@ -1,0 +1,220 @@
+package internal
+
+import (
+	"context"
+	"fmt"
+	model "github.com/ctreminiom/go-atlassian/pkg/infra/models"
+	"github.com/ctreminiom/go-atlassian/service"
+	"github.com/ctreminiom/go-atlassian/service/jira"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+func NewWorkflowStatusService(client service.Client, version string) (*WorkflowStatusService, error) {
+
+	if version == "" {
+		return nil, model.ErrNoVersionProvided
+	}
+
+	return &WorkflowStatusService{
+		internalClient: &internalWorkflowStatusImpl{c: client, version: version},
+	}, nil
+}
+
+type WorkflowStatusService struct {
+	internalClient jira.WorkflowStatusConnector
+}
+
+// Gets returns a list of the statuses specified by one or more status IDs.
+//
+// GET /rest/api/{2-3}/statuses
+//
+// https://docs.go-atlassian.io/jira-software-cloud/workflow/status#gets-workflow-statuses
+func (w *WorkflowStatusService) Gets(ctx context.Context, ids, expand []string) ([]*model.WorkflowStatusDetailScheme, *model.ResponseScheme, error) {
+	return w.internalClient.Gets(ctx, ids, expand)
+}
+
+// Update updates statuses by ID.
+//
+// PUT /rest/api/{2-3}/statuses
+//
+// https://docs.go-atlassian.io/jira-software-cloud/workflow/status#update-workflow-statuses
+func (w *WorkflowStatusService) Update(ctx context.Context, payload *model.WorkflowStatusPayloadScheme) (*model.ResponseScheme, error) {
+	return w.internalClient.Update(ctx, payload)
+}
+
+// Create creates statuses for a global or project scope.
+//
+// POST /rest/api/{2-3}/statuses
+//
+// https://docs.go-atlassian.io/jira-software-cloud/workflow/status#create-workflow-statuses
+func (w *WorkflowStatusService) Create(ctx context.Context, payload *model.WorkflowStatusPayloadScheme) ([]*model.WorkflowStatusDetailScheme, *model.ResponseScheme, error) {
+	return w.internalClient.Create(ctx, payload)
+}
+
+// Delete deletes statuses by ID.
+//
+// DELETE /rest/api/{2-3}/statuses
+//
+// https://docs.go-atlassian.io/jira-software-cloud/workflow/status#delete-workflow-statuses
+func (w *WorkflowStatusService) Delete(ctx context.Context, ids []string) (*model.ResponseScheme, error) {
+	return w.internalClient.Delete(ctx, ids)
+}
+
+// Search returns a paginated list of statuses that match a search on name or project.
+//
+// GET /rest/api/{2-3}/statuses/search
+//
+// https://docs.go-atlassian.io/jira-software-cloud/workflow/status#search-workflow-statuses
+func (w *WorkflowStatusService) Search(ctx context.Context, options *model.WorkflowStatusSearchParams, startAt, maxResults int) (*model.WorkflowStatusDetailPageScheme, *model.ResponseScheme, error) {
+	return w.internalClient.Search(ctx, options, startAt, maxResults)
+}
+
+type internalWorkflowStatusImpl struct {
+	c       service.Client
+	version string
+}
+
+func (i *internalWorkflowStatusImpl) Gets(ctx context.Context, ids, expand []string) ([]*model.WorkflowStatusDetailScheme, *model.ResponseScheme, error) {
+
+	var endpoint strings.Builder
+	endpoint.WriteString(fmt.Sprintf("rest/api/%v/statuses", i.version))
+
+	params := url.Values{}
+	for _, id := range ids {
+		params.Add("id", id)
+	}
+
+	if expand != nil {
+		params.Add("expand", strings.Join(expand, ","))
+	}
+
+	if params.Encode() != "" {
+		endpoint.WriteString(fmt.Sprintf("?%v", params.Encode()))
+	}
+
+	request, err := i.c.NewRequest(ctx, http.MethodGet, endpoint.String(), nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var statuses []*model.WorkflowStatusDetailScheme
+	response, err := i.c.Call(request, &statuses)
+	if err != nil {
+		return nil, response, err
+	}
+
+	return statuses, response, nil
+}
+
+func (i *internalWorkflowStatusImpl) Update(ctx context.Context, payload *model.WorkflowStatusPayloadScheme) (*model.ResponseScheme, error) {
+
+	reader, err := i.c.TransformStructToReader(payload)
+	if err != nil {
+		return nil, err
+	}
+
+	endpoint := fmt.Sprintf("rest/api/%v/statuses", i.version)
+
+	request, err := i.c.NewRequest(ctx, http.MethodPut, endpoint, reader)
+	if err != nil {
+		return nil, err
+	}
+
+	return i.c.Call(request, nil)
+}
+
+func (i *internalWorkflowStatusImpl) Create(ctx context.Context, payload *model.WorkflowStatusPayloadScheme) ([]*model.WorkflowStatusDetailScheme, *model.ResponseScheme, error) {
+
+	reader, err := i.c.TransformStructToReader(payload)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if len(payload.Statuses) == 0 {
+		return nil, nil, model.ErrNoWorkflowStatusesError
+	}
+
+	if payload.Scope == nil {
+		return nil, nil, model.ErrNoWorkflowScopeError
+	}
+
+	endpoint := fmt.Sprintf("rest/api/%v/statuses", i.version)
+
+	request, err := i.c.NewRequest(ctx, http.MethodPost, endpoint, reader)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var workflowStatuses []*model.WorkflowStatusDetailScheme
+	response, err := i.c.Call(request, &workflowStatuses)
+	if err != nil {
+		return nil, response, err
+	}
+
+	return workflowStatuses, response, nil
+}
+
+func (i *internalWorkflowStatusImpl) Delete(ctx context.Context, ids []string) (*model.ResponseScheme, error) {
+
+	if len(ids) == 0 {
+		return nil, model.ErrNoWorkflowStatusesError
+	}
+
+	params := url.Values{}
+	for _, id := range ids {
+		params.Add("id", id)
+	}
+
+	endpoint := fmt.Sprintf("rest/api/%v/statuses?%v", i.version, params.Encode())
+
+	request, err := i.c.NewRequest(ctx, http.MethodDelete, endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return i.c.Call(request, nil)
+}
+
+func (i *internalWorkflowStatusImpl) Search(ctx context.Context, options *model.WorkflowStatusSearchParams, startAt, maxResults int) (*model.WorkflowStatusDetailPageScheme, *model.ResponseScheme, error) {
+
+	params := url.Values{}
+	params.Add("startAt", strconv.Itoa(startAt))
+	params.Add("maxResults", strconv.Itoa(maxResults))
+
+	if options != nil {
+
+		if options.Expand != nil {
+			params.Add("expand", strings.Join(options.Expand, ","))
+		}
+
+		if options.ProjectID != "" {
+			params.Add("projectId", options.ProjectID)
+		}
+
+		if options.SearchString != "" {
+			params.Add("searchString", options.SearchString)
+		}
+
+		if options.StatusCategory != "" {
+			params.Add("statusCategory", options.StatusCategory)
+		}
+	}
+
+	endpoint := fmt.Sprintf("rest/api/%v/statuses/search?%v", i.version, params.Encode())
+
+	request, err := i.c.NewRequest(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	page := new(model.WorkflowStatusDetailPageScheme)
+	response, err := i.c.Call(request, page)
+	if err != nil {
+		return nil, response, err
+	}
+
+	return page, response, nil
+}

--- a/jira/internal/workflow_status_impl_test.go
+++ b/jira/internal/workflow_status_impl_test.go
@@ -1,0 +1,840 @@
+package internal
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	model "github.com/ctreminiom/go-atlassian/pkg/infra/models"
+	"github.com/ctreminiom/go-atlassian/service"
+	"github.com/ctreminiom/go-atlassian/service/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"net/http"
+	"testing"
+)
+
+func Test_internalWorkflowStatusImpl_Gets(t *testing.T) {
+
+	type fields struct {
+		c       service.Client
+		version string
+	}
+
+	type args struct {
+		ctx         context.Context
+		ids, expand []string
+	}
+
+	testCases := []struct {
+		name    string
+		fields  fields
+		args    args
+		on      func(*fields)
+		wantErr bool
+		Err     error
+	}{
+		{
+			name:   "when the api version is v3",
+			fields: fields{version: "3"},
+			args: args{
+				ctx:    context.TODO(),
+				ids:    []string{"10000", "10001"},
+				expand: []string{"usages"},
+			},
+			on: func(fields *fields) {
+
+				client := mocks.NewClient(t)
+
+				client.On("NewRequest",
+					context.Background(),
+					http.MethodGet,
+					"rest/api/3/statuses?expand=usages&id=10000&id=10001",
+					nil).
+					Return(&http.Request{}, nil)
+
+				client.On("Call",
+					&http.Request{},
+					mock.Anything).
+					Return(&model.ResponseScheme{}, nil)
+
+				fields.c = client
+			},
+			wantErr: false,
+			Err:     nil,
+		},
+
+		{
+			name:   "when the api version is v2",
+			fields: fields{version: "2"},
+			args: args{
+				ctx:    context.TODO(),
+				ids:    []string{"10000", "10001"},
+				expand: []string{"usages"},
+			},
+			on: func(fields *fields) {
+
+				client := mocks.NewClient(t)
+
+				client.On("NewRequest",
+					context.Background(),
+					http.MethodGet,
+					"rest/api/2/statuses?expand=usages&id=10000&id=10001",
+					nil).
+					Return(&http.Request{}, nil)
+
+				client.On("Call",
+					&http.Request{},
+					mock.Anything).
+					Return(&model.ResponseScheme{}, nil)
+
+				fields.c = client
+			},
+			wantErr: false,
+			Err:     nil,
+		},
+
+		{
+			name:   "when the http request cannot be created",
+			fields: fields{version: "3"},
+			args: args{
+				ctx:    context.TODO(),
+				ids:    []string{"10000", "10001"},
+				expand: []string{"usages"},
+			},
+			on: func(fields *fields) {
+
+				client := mocks.NewClient(t)
+
+				client.On("NewRequest",
+					context.Background(),
+					http.MethodGet,
+					"rest/api/3/statuses?expand=usages&id=10000&id=10001",
+					nil).
+					Return(&http.Request{}, errors.New("error, unable to create the http request"))
+
+				fields.c = client
+			},
+			wantErr: true,
+			Err:     errors.New("error, unable to create the http request"),
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+
+			if testCase.on != nil {
+				testCase.on(&testCase.fields)
+			}
+
+			newService, err := NewWorkflowStatusService(testCase.fields.c, testCase.fields.version)
+			assert.NoError(t, err)
+
+			gotResult, gotResponse, err := newService.Gets(testCase.args.ctx, testCase.args.ids, testCase.args.expand)
+
+			if testCase.wantErr {
+
+				if err != nil {
+					t.Logf("error returned: %v", err.Error())
+				}
+
+				assert.EqualError(t, err, testCase.Err.Error())
+
+			} else {
+
+				assert.NoError(t, err)
+				assert.NotEqual(t, gotResponse, nil)
+				assert.NotEqual(t, gotResult, nil)
+			}
+
+		})
+	}
+}
+
+func Test_internalWorkflowStatusImpl_Update(t *testing.T) {
+
+	payloadMocked := &model.WorkflowStatusPayloadScheme{
+		Statuses: []*model.WorkflowStatusNodeScheme{
+			{
+				ID:             "1000",
+				Name:           "Finished",
+				StatusCategory: "DONE",
+				Description:    "The issue is resolved",
+			},
+			{
+				ID:             "1000",
+				Name:           "Cancelled",
+				StatusCategory: "DONE",
+				Description:    "The issue is cancelled",
+			},
+		},
+	}
+
+	type fields struct {
+		c       service.Client
+		version string
+	}
+
+	type args struct {
+		ctx     context.Context
+		payload *model.WorkflowStatusPayloadScheme
+	}
+
+	testCases := []struct {
+		name    string
+		fields  fields
+		args    args
+		on      func(*fields)
+		wantErr bool
+		Err     error
+	}{
+		{
+			name:   "when the api version is v3",
+			fields: fields{version: "3"},
+			args: args{
+				ctx:     context.TODO(),
+				payload: payloadMocked,
+			},
+			on: func(fields *fields) {
+
+				client := mocks.NewClient(t)
+
+				client.On("TransformStructToReader",
+					payloadMocked).
+					Return(bytes.NewReader([]byte{}), nil)
+
+				client.On("NewRequest",
+					context.Background(),
+					http.MethodPut,
+					"rest/api/3/statuses",
+					bytes.NewReader([]byte{})).
+					Return(&http.Request{}, nil)
+
+				client.On("Call",
+					&http.Request{},
+					nil).
+					Return(&model.ResponseScheme{}, nil)
+
+				fields.c = client
+			},
+			wantErr: false,
+			Err:     nil,
+		},
+
+		{
+			name:   "when the api version is v2",
+			fields: fields{version: "2"},
+			args: args{
+				ctx:     context.TODO(),
+				payload: payloadMocked,
+			},
+			on: func(fields *fields) {
+
+				client := mocks.NewClient(t)
+
+				client.On("TransformStructToReader",
+					payloadMocked).
+					Return(bytes.NewReader([]byte{}), nil)
+
+				client.On("NewRequest",
+					context.Background(),
+					http.MethodPut,
+					"rest/api/2/statuses",
+					bytes.NewReader([]byte{})).
+					Return(&http.Request{}, nil)
+
+				client.On("Call",
+					&http.Request{},
+					nil).
+					Return(&model.ResponseScheme{}, nil)
+
+				fields.c = client
+			},
+			wantErr: false,
+			Err:     nil,
+		},
+
+		{
+			name:   "when the http request cannot be created",
+			fields: fields{version: "3"},
+			args: args{
+				ctx:     context.TODO(),
+				payload: payloadMocked,
+			},
+			on: func(fields *fields) {
+
+				client := mocks.NewClient(t)
+
+				client.On("TransformStructToReader",
+					payloadMocked).
+					Return(bytes.NewReader([]byte{}), nil)
+
+				client.On("NewRequest",
+					context.Background(),
+					http.MethodPut,
+					"rest/api/3/statuses",
+					bytes.NewReader([]byte{})).
+					Return(&http.Request{}, errors.New("error, unable to create the http request"))
+
+				fields.c = client
+			},
+			wantErr: true,
+			Err:     errors.New("error, unable to create the http request"),
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+
+			if testCase.on != nil {
+				testCase.on(&testCase.fields)
+			}
+
+			newService, err := NewWorkflowStatusService(testCase.fields.c, testCase.fields.version)
+			assert.NoError(t, err)
+
+			gotResponse, err := newService.Update(testCase.args.ctx, testCase.args.payload)
+
+			if testCase.wantErr {
+
+				if err != nil {
+					t.Logf("error returned: %v", err.Error())
+				}
+
+				assert.EqualError(t, err, testCase.Err.Error())
+
+			} else {
+
+				assert.NoError(t, err)
+				assert.NotEqual(t, gotResponse, nil)
+			}
+
+		})
+	}
+}
+
+func Test_internalWorkflowStatusImpl_Create(t *testing.T) {
+
+	payloadMocked := &model.WorkflowStatusPayloadScheme{
+		Statuses: []*model.WorkflowStatusNodeScheme{
+			{
+				Name:           "UAT",
+				StatusCategory: "IN_PROGRESS",
+			},
+			{
+				Name:           "Stage",
+				StatusCategory: "IN_PROGRESS",
+			},
+		},
+		Scope: &model.WorkflowStatusScopeScheme{
+			Type: "PROJECT",
+			Project: &model.WorkflowStatusProjectScheme{
+				ID: "10023",
+			},
+		},
+	}
+
+	payloadMockedWithOutStatuses := &model.WorkflowStatusPayloadScheme{
+		Scope: &model.WorkflowStatusScopeScheme{
+			Type: "PROJECT",
+			Project: &model.WorkflowStatusProjectScheme{
+				ID: "10023",
+			},
+		},
+	}
+
+	payloadMockedWithOutScope := &model.WorkflowStatusPayloadScheme{
+		Statuses: []*model.WorkflowStatusNodeScheme{
+			{
+				Name:           "UAT",
+				StatusCategory: "IN_PROGRESS",
+			},
+			{
+				Name:           "Stage",
+				StatusCategory: "IN_PROGRESS",
+			},
+		},
+	}
+
+	type fields struct {
+		c       service.Client
+		version string
+	}
+
+	type args struct {
+		ctx     context.Context
+		payload *model.WorkflowStatusPayloadScheme
+	}
+
+	testCases := []struct {
+		name    string
+		fields  fields
+		args    args
+		on      func(*fields)
+		wantErr bool
+		Err     error
+	}{
+		{
+			name:   "when the api version is v3",
+			fields: fields{version: "3"},
+			args: args{
+				ctx:     context.TODO(),
+				payload: payloadMocked,
+			},
+			on: func(fields *fields) {
+
+				client := mocks.NewClient(t)
+
+				client.On("TransformStructToReader",
+					payloadMocked).
+					Return(bytes.NewReader([]byte{}), nil)
+
+				client.On("NewRequest",
+					context.Background(),
+					http.MethodPost,
+					"rest/api/3/statuses",
+					bytes.NewReader([]byte{})).
+					Return(&http.Request{}, nil)
+
+				client.On("Call",
+					&http.Request{},
+					mock.Anything).
+					Return(&model.ResponseScheme{}, nil)
+
+				fields.c = client
+			},
+			wantErr: false,
+			Err:     nil,
+		},
+
+		{
+			name:   "when the api version is v2",
+			fields: fields{version: "2"},
+			args: args{
+				ctx:     context.TODO(),
+				payload: payloadMocked,
+			},
+			on: func(fields *fields) {
+
+				client := mocks.NewClient(t)
+				client.On("TransformStructToReader",
+					payloadMocked).
+					Return(bytes.NewReader([]byte{}), nil)
+
+				client.On("NewRequest",
+					context.Background(),
+					http.MethodPost,
+					"rest/api/2/statuses",
+					bytes.NewReader([]byte{})).
+					Return(&http.Request{}, nil)
+
+				client.On("Call",
+					&http.Request{},
+					mock.Anything).
+					Return(&model.ResponseScheme{}, nil)
+				fields.c = client
+			},
+			wantErr: false,
+			Err:     nil,
+		},
+
+		{
+			name:   "when the payload does not have statuses",
+			fields: fields{version: "3"},
+			args: args{
+				ctx:     context.TODO(),
+				payload: payloadMockedWithOutStatuses,
+			},
+			on: func(fields *fields) {
+
+				client := mocks.NewClient(t)
+
+				client.On("TransformStructToReader",
+					payloadMockedWithOutStatuses).
+					Return(bytes.NewReader([]byte{}), nil)
+
+				fields.c = client
+			},
+			wantErr: true,
+			Err:     model.ErrNoWorkflowStatusesError,
+		},
+
+		{
+			name:   "when the payload does not have a scope",
+			fields: fields{version: "3"},
+			args: args{
+				ctx:     context.TODO(),
+				payload: payloadMockedWithOutScope,
+			},
+			on: func(fields *fields) {
+
+				client := mocks.NewClient(t)
+
+				client.On("TransformStructToReader",
+					payloadMockedWithOutScope).
+					Return(bytes.NewReader([]byte{}), nil)
+
+				fields.c = client
+			},
+			wantErr: true,
+			Err:     model.ErrNoWorkflowScopeError,
+		},
+
+		{
+			name:   "when the http request cannot be created",
+			fields: fields{version: "3"},
+			args: args{
+				ctx:     context.TODO(),
+				payload: payloadMocked,
+			},
+			on: func(fields *fields) {
+
+				client := mocks.NewClient(t)
+
+				client.On("TransformStructToReader",
+					payloadMocked).
+					Return(bytes.NewReader([]byte{}), nil)
+
+				client.On("NewRequest",
+					context.Background(),
+					http.MethodPost,
+					"rest/api/3/statuses",
+					bytes.NewReader([]byte{})).
+					Return(&http.Request{}, errors.New("error, unable to create the http request"))
+
+				fields.c = client
+			},
+			wantErr: true,
+			Err:     errors.New("error, unable to create the http request"),
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+
+			if testCase.on != nil {
+				testCase.on(&testCase.fields)
+			}
+
+			newService, err := NewWorkflowStatusService(testCase.fields.c, testCase.fields.version)
+			assert.NoError(t, err)
+
+			gotResult, gotResponse, err := newService.Create(testCase.args.ctx, testCase.args.payload)
+
+			if testCase.wantErr {
+
+				if err != nil {
+					t.Logf("error returned: %v", err.Error())
+				}
+
+				assert.EqualError(t, err, testCase.Err.Error())
+
+			} else {
+
+				assert.NoError(t, err)
+				assert.NotEqual(t, gotResponse, nil)
+				assert.NotEqual(t, gotResult, nil)
+			}
+
+		})
+	}
+}
+
+func Test_internalWorkflowStatusImpl_Delete(t *testing.T) {
+
+	type fields struct {
+		c       service.Client
+		version string
+	}
+
+	type args struct {
+		ctx context.Context
+		ids []string
+	}
+
+	testCases := []struct {
+		name    string
+		fields  fields
+		args    args
+		on      func(*fields)
+		wantErr bool
+		Err     error
+	}{
+		{
+			name:   "when the api version is v3",
+			fields: fields{version: "3"},
+			args: args{
+				ctx: context.TODO(),
+				ids: []string{"10000", "10001"},
+			},
+			on: func(fields *fields) {
+
+				client := mocks.NewClient(t)
+
+				client.On("NewRequest",
+					context.Background(),
+					http.MethodDelete,
+					"rest/api/3/statuses?id=10000&id=10001",
+					nil).
+					Return(&http.Request{}, nil)
+
+				client.On("Call",
+					&http.Request{},
+					nil).
+					Return(&model.ResponseScheme{}, nil)
+
+				fields.c = client
+			},
+			wantErr: false,
+			Err:     nil,
+		},
+
+		{
+			name:   "when the api version is v2",
+			fields: fields{version: "2"},
+			args: args{
+				ctx: context.TODO(),
+				ids: []string{"10000", "10001"},
+			},
+			on: func(fields *fields) {
+
+				client := mocks.NewClient(t)
+
+				client.On("NewRequest",
+					context.Background(),
+					http.MethodDelete,
+					"rest/api/2/statuses?id=10000&id=10001",
+					nil).
+					Return(&http.Request{}, nil)
+
+				client.On("Call",
+					&http.Request{},
+					nil).
+					Return(&model.ResponseScheme{}, nil)
+
+				fields.c = client
+			},
+			wantErr: false,
+			Err:     nil,
+		},
+
+		{
+			name:   "when the statuses ids are not provided",
+			fields: fields{version: "3"},
+			args: args{
+				ctx: context.TODO(),
+			},
+			wantErr: true,
+			Err:     model.ErrNoWorkflowStatusesError,
+		},
+
+		{
+			name:   "when the http request cannot be created",
+			fields: fields{version: "3"},
+			args: args{
+				ctx: context.TODO(),
+				ids: []string{"10000", "10001"},
+			},
+			on: func(fields *fields) {
+
+				client := mocks.NewClient(t)
+
+				client.On("NewRequest",
+					context.Background(),
+					http.MethodDelete,
+					"rest/api/3/statuses?id=10000&id=10001",
+					nil).
+					Return(&http.Request{}, errors.New("error, unable to create the http request"))
+
+				fields.c = client
+			},
+			wantErr: true,
+			Err:     errors.New("error, unable to create the http request"),
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+
+			if testCase.on != nil {
+				testCase.on(&testCase.fields)
+			}
+
+			newService, err := NewWorkflowStatusService(testCase.fields.c, testCase.fields.version)
+			assert.NoError(t, err)
+
+			gotResponse, err := newService.Delete(testCase.args.ctx, testCase.args.ids)
+
+			if testCase.wantErr {
+
+				if err != nil {
+					t.Logf("error returned: %v", err.Error())
+				}
+
+				assert.EqualError(t, err, testCase.Err.Error())
+
+			} else {
+
+				assert.NoError(t, err)
+				assert.NotEqual(t, gotResponse, nil)
+			}
+
+		})
+	}
+}
+
+func Test_internalWorkflowStatusImpl_Search(t *testing.T) {
+
+	type fields struct {
+		c       service.Client
+		version string
+	}
+
+	type args struct {
+		ctx                 context.Context
+		options             *model.WorkflowStatusSearchParams
+		startAt, maxResults int
+	}
+
+	testCases := []struct {
+		name    string
+		fields  fields
+		args    args
+		on      func(*fields)
+		wantErr bool
+		Err     error
+	}{
+		{
+			name:   "when the api version is v3",
+			fields: fields{version: "3"},
+			args: args{
+				ctx: context.TODO(),
+				options: &model.WorkflowStatusSearchParams{
+					ProjectID:      "8373772",
+					SearchString:   "UAT",
+					StatusCategory: "IN_PROGRESS",
+					Expand:         []string{"usages"},
+				},
+				startAt:    0,
+				maxResults: 50,
+			},
+			on: func(fields *fields) {
+
+				client := mocks.NewClient(t)
+
+				client.On("NewRequest",
+					context.Background(),
+					http.MethodGet,
+					"rest/api/3/statuses/search?expand=usages&maxResults=50&projectId=8373772&searchString=UAT&startAt=0&statusCategory=IN_PROGRESS",
+					nil).
+					Return(&http.Request{}, nil)
+
+				client.On("Call",
+					&http.Request{},
+					&model.WorkflowStatusDetailPageScheme{}).
+					Return(&model.ResponseScheme{}, nil)
+
+				fields.c = client
+			},
+			wantErr: false,
+			Err:     nil,
+		},
+
+		{
+			name:   "when the api version is v2",
+			fields: fields{version: "2"},
+			args: args{
+				ctx: context.TODO(),
+				options: &model.WorkflowStatusSearchParams{
+					ProjectID:      "8373772",
+					SearchString:   "UAT",
+					StatusCategory: "IN_PROGRESS",
+					Expand:         []string{"usages"},
+				},
+				startAt:    0,
+				maxResults: 50,
+			},
+			on: func(fields *fields) {
+
+				client := mocks.NewClient(t)
+
+				client.On("NewRequest",
+					context.Background(),
+					http.MethodGet,
+					"rest/api/2/statuses/search?expand=usages&maxResults=50&projectId=8373772&searchString=UAT&startAt=0&statusCategory=IN_PROGRESS",
+					nil).
+					Return(&http.Request{}, nil)
+
+				client.On("Call",
+					&http.Request{},
+					&model.WorkflowStatusDetailPageScheme{}).
+					Return(&model.ResponseScheme{}, nil)
+
+				fields.c = client
+			},
+			wantErr: false,
+			Err:     nil,
+		},
+
+		{
+			name:   "when the http request cannot be created",
+			fields: fields{version: "3"},
+			args: args{
+				ctx: context.TODO(),
+				options: &model.WorkflowStatusSearchParams{
+					ProjectID:      "8373772",
+					SearchString:   "UAT",
+					StatusCategory: "IN_PROGRESS",
+					Expand:         []string{"usages"},
+				},
+				startAt:    0,
+				maxResults: 50,
+			},
+			on: func(fields *fields) {
+
+				client := mocks.NewClient(t)
+
+				client.On("NewRequest",
+					context.Background(),
+					http.MethodGet,
+					"rest/api/3/statuses/search?expand=usages&maxResults=50&projectId=8373772&searchString=UAT&startAt=0&statusCategory=IN_PROGRESS",
+					nil).
+					Return(&http.Request{}, errors.New("error, unable to create the http request"))
+
+				fields.c = client
+			},
+			wantErr: true,
+			Err:     errors.New("error, unable to create the http request"),
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+
+			if testCase.on != nil {
+				testCase.on(&testCase.fields)
+			}
+
+			newService, err := NewWorkflowStatusService(testCase.fields.c, testCase.fields.version)
+			assert.NoError(t, err)
+
+			gotResult, gotResponse, err := newService.Search(testCase.args.ctx, testCase.args.options, testCase.args.startAt,
+				testCase.args.maxResults)
+
+			if testCase.wantErr {
+
+				if err != nil {
+					t.Logf("error returned: %v", err.Error())
+				}
+
+				assert.EqualError(t, err, testCase.Err.Error())
+
+			} else {
+
+				assert.NoError(t, err)
+				assert.NotEqual(t, gotResponse, nil)
+				assert.NotEqual(t, gotResult, nil)
+			}
+
+		})
+	}
+}

--- a/jira/v2/api_client_impl.go
+++ b/jira/v2/api_client_impl.go
@@ -325,7 +325,12 @@ func New(httpClient common.HttpClient, site string) (*Client, error) {
 		return nil, err
 	}
 
-	workflow, err := internal.NewWorkflowService(client, "2", workflowScheme)
+	workflowStatus, err := internal.NewWorkflowStatusService(client, "2")
+	if err != nil {
+		return nil, err
+	}
+
+	workflow, err := internal.NewWorkflowService(client, "2", workflowScheme, workflowStatus)
 	if err != nil {
 		return nil, err
 	}

--- a/jira/v3/api_client_impl.go
+++ b/jira/v3/api_client_impl.go
@@ -325,7 +325,12 @@ func New(httpClient common.HttpClient, site string) (*Client, error) {
 		return nil, err
 	}
 
-	workflow, err := internal.NewWorkflowService(client, "3", workflowScheme)
+	workflowStatus, err := internal.NewWorkflowStatusService(client, "3")
+	if err != nil {
+		return nil, err
+	}
+
+	workflow, err := internal.NewWorkflowService(client, "3", workflowScheme, workflowStatus)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/infra/models/errors.go
+++ b/pkg/infra/models/errors.go
@@ -63,6 +63,8 @@ var (
 	ErrNoPropertyKeyError                  = errors.New("jira: no property key set")
 	ErrNoProjectFeatureKeyError            = errors.New("jira: no project feature key set")
 	ErrNoFieldIDError                      = errors.New("jira: no field id set")
+	ErrNoWorkflowStatusesError             = errors.New("jira: no workflow statuses set")
+	ErrNoWorkflowScopeError                = errors.New("jira: no workflow scope set")
 	ErrNoFieldContextIDError               = errors.New("jira: no field context id set")
 	ErrNoIssueTypesError                   = errors.New("jira: no issue types id's set")
 	ErrNoProjectsError                     = errors.New("jira: no projects set")

--- a/pkg/infra/models/jira_workflow_status.go
+++ b/pkg/infra/models/jira_workflow_status.go
@@ -1,0 +1,53 @@
+package models
+
+type WorkflowStatusDetailPageScheme struct {
+	StartAt    int                           `json:"startAt,omitempty"`
+	Total      int                           `json:"total,omitempty"`
+	IsLast     bool                          `json:"isLast,omitempty"`
+	MaxResults int                           `json:"maxResults,omitempty"`
+	Values     []*WorkflowStatusDetailScheme `json:"values,omitempty"`
+	Self       string                        `json:"self,omitempty"`
+	NextPage   string                        `json:"nextPage,omitempty"`
+}
+
+type WorkflowStatusDetailScheme struct {
+	ID             string                     `json:"id,omitempty"`
+	Name           string                     `json:"name,omitempty"`
+	StatusCategory string                     `json:"statusCategory,omitempty"`
+	Scope          *WorkflowStatusScopeScheme `json:"scope,omitempty"`
+	Description    string                     `json:"description,omitempty"`
+	Usages         []*ProjectIssueTypesScheme `json:"usages,omitempty"`
+}
+
+type WorkflowStatusScopeScheme struct {
+	Type    string                       `json:"type,omitempty"`
+	Project *WorkflowStatusProjectScheme `json:"project,omitempty"`
+}
+
+type WorkflowStatusProjectScheme struct {
+	ID string `json:"id,omitempty"`
+}
+
+type ProjectIssueTypesScheme struct {
+	Project    *ProjectScheme `json:"project,omitempty"`
+	IssueTypes []string       `json:"issueTypes,omitempty"`
+}
+
+type WorkflowStatusPayloadScheme struct {
+	Statuses []*WorkflowStatusNodeScheme `json:"statuses,omitempty"`
+	Scope    *WorkflowStatusScopeScheme  `json:"scope,omitempty"`
+}
+
+type WorkflowStatusNodeScheme struct {
+	ID             string `json:"id,omitempty"`
+	Name           string `json:"name,omitempty"`
+	StatusCategory string `json:"statusCategory,omitempty"`
+	Description    string `json:"description,omitempty"`
+}
+
+type WorkflowStatusSearchParams struct {
+	ProjectID      string
+	SearchString   string
+	StatusCategory string
+	Expand         []string
+}

--- a/service/jira/workflow.go
+++ b/service/jira/workflow.go
@@ -113,3 +113,45 @@ type WorkflowSchemeConnector interface {
 	// https://docs.go-atlassian.io/jira-software-cloud/workflow/scheme#get-workflow-schemes-associations
 	Assign(ctx context.Context, schemeId, projectId string) (*model.ResponseScheme, error)
 }
+
+// WorkflowStatusConnector represents the workflows statuses.
+//
+// Use it to search, get, create, delete, and change statuses.
+type WorkflowStatusConnector interface {
+
+	// Gets returns a list of the statuses specified by one or more status IDs.
+	//
+	// GET /rest/api/{2-3}/statuses
+	//
+	// https://docs.go-atlassian.io/jira-software-cloud/workflow/status#gets-workflow-statuses
+	Gets(ctx context.Context, ids, expand []string) ([]*model.WorkflowStatusDetailScheme, *model.ResponseScheme, error)
+
+	// Update updates statuses by ID.
+	//
+	// PUT /rest/api/{2-3}/statuses
+	//
+	// https://docs.go-atlassian.io/jira-software-cloud/workflow/status#update-workflow-statuses
+	Update(ctx context.Context, payload *model.WorkflowStatusPayloadScheme) (*model.ResponseScheme, error)
+
+	// Create creates statuses for a global or project scope.
+	//
+	// POST /rest/api/{2-3}/statuses
+	//
+	// https://docs.go-atlassian.io/jira-software-cloud/workflow/status#create-workflow-statuses
+	Create(ctx context.Context, payload *model.WorkflowStatusPayloadScheme) ([]*model.WorkflowStatusDetailScheme, *model.ResponseScheme, error)
+
+	// Delete deletes statuses by ID.
+	//
+	// DELETE /rest/api/{2-3}/statuses
+	//
+	// https://docs.go-atlassian.io/jira-software-cloud/workflow/status#delete-workflow-statuses
+	Delete(ctx context.Context, ids []string) (*model.ResponseScheme, error)
+
+	// Search returns a paginated list of statuses that match a search on name or project.
+	//
+	// GET /rest/api/{2-3}/statuses/search
+	//
+	// https://docs.go-atlassian.io/jira-software-cloud/workflow/status#search-workflow-statuses
+	Search(ctx context.Context, options *model.WorkflowStatusSearchParams, startAt, maxResults int) (*model.WorkflowStatusDetailPageScheme,
+		*model.ResponseScheme, error)
+}


### PR DESCRIPTION
1. Created the interface called WorkflowStatusConnector which contains the service contract.

2. Created the WorkflowStatusService struct with the service implementation under workflow_status_impl.go

3. Created the dedicated structs under jira_workflow_status.go

4. Injected the service implementation under the WorkflowService struct (Workflow.Status.*)

5. Created the Unit Test Cases with a 92.5% of coverage

6. Fixes #140