### PR TITLE
Added the expand option to the internalSearch implementation for content

### DIFF
--- a/confluence/internal/search_impl.go
+++ b/confluence/internal/search_impl.go
@@ -99,6 +99,12 @@ func (i *internalSearchImpl) Content(ctx context.Context, cql string, options *m
 		if options.SitePermissionTypeFilter != "" {
 			query.Add("sitePermissionTypeFilter", options.SitePermissionTypeFilter)
 		}
+
+		if len(options.Expand) > 0 {
+			for _, value := range options.Expand {
+				query.Add("expand", value)
+			}
+		}
 	}
 
 	endpoint := fmt.Sprintf("wiki/rest/api/search?%v", query.Encode())

--- a/confluence/internal/search_impl_test.go
+++ b/confluence/internal/search_impl_test.go
@@ -57,7 +57,7 @@ func Test_internalSearchImpl_Content(t *testing.T) {
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodGet,
-					"wiki/rest/api/search?cql=type%3Dpage&cqlcontext=spaceKey&cursor=raNDoMsTRiNg&excerpt=indexed&excludeCurrentSpaces=true&includeArchivedSpaces=true&limit=20&next=true&prev=true&sitePermissionTypeFilter=externalCollaborator&start=10",
+					"wiki/rest/api/search?cql=type%3Dpage&cqlcontext=spaceKey&cursor=raNDoMsTRiNg&excerpt=indexed&excludeCurrentSpaces=true&expand=space&includeArchivedSpaces=true&limit=20&next=true&prev=true&sitePermissionTypeFilter=externalCollaborator&start=10",
 					nil).
 					Return(&http.Request{}, nil)
 
@@ -97,7 +97,7 @@ func Test_internalSearchImpl_Content(t *testing.T) {
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodGet,
-					"wiki/rest/api/search?cql=type%3Dpage&cqlcontext=spaceKey&cursor=raNDoMsTRiNg&excerpt=indexed&excludeCurrentSpaces=true&includeArchivedSpaces=true&limit=20&next=true&prev=true&sitePermissionTypeFilter=externalCollaborator&start=10",
+					"wiki/rest/api/search?cql=type%3Dpage&cqlcontext=spaceKey&cursor=raNDoMsTRiNg&excerpt=indexed&excludeCurrentSpaces=true&expand=space&includeArchivedSpaces=true&limit=20&next=true&prev=true&sitePermissionTypeFilter=externalCollaborator&start=10",
 					nil).
 					Return(&http.Request{}, errors.New("error, unable to create the http request"))
 


### PR DESCRIPTION
# Background
The internal content search implementation currently does not propagate the "expand" option to the underlying query. This does not allow the user to pass that parameter in.

I adjusted the appropriate tests.