### PR TITLE
Add Support for Filtering Confluence V2 Bulk

### DIFF
--- a/confluence/internal/page_impl.go
+++ b/confluence/internal/page_impl.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 )
 
 // NewPageService returns a new Confluence V2 Page service
@@ -40,8 +41,8 @@ func (p *PageService) Get(ctx context.Context, pageID int, format string, draft 
 // GET /wiki/api/v2/pages
 //
 // https://docs.go-atlassian.io/confluence-cloud/v2/page#get-pages
-func (p *PageService) Bulk(ctx context.Context, cursor string, limit int) (*model.PageChunkScheme, *model.ResponseScheme, error) {
-	return p.internalClient.Bulk(ctx, cursor, limit)
+func (p *PageService) Bulk(ctx context.Context, cursor string, limit int, pageIDs ...int) (*model.PageChunkScheme, *model.ResponseScheme, error) {
+	return p.internalClient.Bulk(ctx, cursor, limit, pageIDs...)
 }
 
 // GetsByLabel returns the pages of specified label.
@@ -141,10 +142,17 @@ func (i *internalPageImpl) Get(ctx context.Context, pageID int, format string, d
 	return page, response, nil
 }
 
-func (i *internalPageImpl) Bulk(ctx context.Context, cursor string, limit int) (*model.PageChunkScheme, *model.ResponseScheme, error) {
+func (i *internalPageImpl) Bulk(ctx context.Context, cursor string, limit int, pageIDs ...int) (*model.PageChunkScheme, *model.ResponseScheme, error) {
 
 	query := url.Values{}
 	query.Add("limit", strconv.Itoa(limit))
+	if len(pageIDs) > 0 {
+		ids := make([]string, 0, len(pageIDs))
+		for _, id := range pageIDs {
+			ids = append(ids, strconv.Itoa(id))
+		}
+		query.Add("id", strings.Join(ids, ","))
+	}
 
 	if cursor != "" {
 		query.Add("cursor", cursor)

--- a/service/confluence/page.go
+++ b/service/confluence/page.go
@@ -25,7 +25,18 @@ type PageConnector interface {
 	// GET /wiki/api/v2/pages
 	//
 	// https://docs.go-atlassian.io/confluence-cloud/v2/page#get-pages
-	Bulk(ctx context.Context, cursor string, limit int, pageIDs... int) (*models.PageChunkScheme, *models.ResponseScheme, error)
+	Bulk(ctx context.Context, cursor string, limit int) (*models.PageChunkScheme, *models.ResponseScheme, error)
+
+	// BulkFiltered returns all pages that fit the filtering criteria.
+	//
+	// The number of results is limited by the limit parameter and additional results
+	//
+	// (if available) will be available through the next cursor
+	//
+	// GET /wiki/api/v2/pages
+	//
+	// https://docs.go-atlassian.io/confluence-cloud/v2/page#get-pages
+	BulkFiltered(ctx context.Context, status, format, cursor string, limit int, pageIDs ...int) (*models.PageChunkScheme, *models.ResponseScheme, error)
 
 	// GetsByLabel returns the pages of specified label.
 	//

--- a/service/confluence/page.go
+++ b/service/confluence/page.go
@@ -25,7 +25,7 @@ type PageConnector interface {
 	// GET /wiki/api/v2/pages
 	//
 	// https://docs.go-atlassian.io/confluence-cloud/v2/page#get-pages
-	Bulk(ctx context.Context, cursor string, limit int) (*models.PageChunkScheme, *models.ResponseScheme, error)
+	Bulk(ctx context.Context, cursor string, limit int, pageIDs... int) (*models.PageChunkScheme, *models.ResponseScheme, error)
 
 	// GetsByLabel returns the pages of specified label.
 	//


### PR DESCRIPTION
The Confluence V2 API Bulk get supports filtering by IDs and status. This adds
support for those and body-format in the form of an additional method `BulkFiltered()`.

Fixes #218.