### PR TITLE
🏗️ Improved the HTTP Client implementation on the SM module

### DIFF
--- a/jira/agile/api_client_impl.go
+++ b/jira/agile/api_client_impl.go
@@ -67,8 +67,7 @@ func (c *Client) NewRequest(ctx context.Context, method, urlStr, type_ string, b
 
 	buf := new(bytes.Buffer)
 	if body != nil {
-		err := json.NewEncoder(buf).Encode(body)
-		if err != nil {
+		if err = json.NewEncoder(buf).Encode(body); err != nil {
 			return nil, err
 		}
 	}

--- a/jira/sm/api_client_impl.go
+++ b/jira/sm/api_client_impl.go
@@ -120,6 +120,10 @@ func (c *Client) NewRequest(ctx context.Context, method, urlStr, type_ string, b
 		req.SetBasicAuth(c.Auth.GetBasicAuth())
 	}
 
+	if c.Auth.HasSetExperimentalFlag() {
+		req.Header.Set("X-ExperimentalApi", "opt-in")
+	}
+
 	if c.Auth.HasUserAgent() {
 		req.Header.Set("User-Agent", c.Auth.GetUserAgent())
 	}

--- a/jira/sm/api_client_impl.go
+++ b/jira/sm/api_client_impl.go
@@ -97,8 +97,7 @@ func (c *Client) NewRequest(ctx context.Context, method, urlStr, type_ string, b
 
 	buf := new(bytes.Buffer)
 	if body != nil {
-		err := json.NewEncoder(buf).Encode(body)
-		if err != nil {
+		if err = json.NewEncoder(buf).Encode(body); err != nil {
 			return nil, err
 		}
 	}

--- a/jira/sm/api_client_impl.go
+++ b/jira/sm/api_client_impl.go
@@ -114,6 +114,7 @@ func (c *Client) NewRequest(ctx context.Context, method, urlStr, type_ string, b
 
 	if body != nil && type_ != "" {
 		req.Header.Set("Content-Type", type_)
+		req.Header.Set("X-Atlassian-Token", "no-check")
 	}
 
 	if c.Auth.HasBasicAuth() {

--- a/jira/sm/api_client_impl.go
+++ b/jira/sm/api_client_impl.go
@@ -5,14 +5,15 @@ import (
 	"context"
 	"encoding/json"
 	"github.com/ctreminiom/go-atlassian/jira/sm/internal"
-	"github.com/ctreminiom/go-atlassian/pkg/infra/models"
+	model "github.com/ctreminiom/go-atlassian/pkg/infra/models"
 	"github.com/ctreminiom/go-atlassian/service/common"
 	"io"
 	"net/http"
 	"net/url"
-	"reflect"
 	"strings"
 )
+
+const defaultServiceManagementVersion = "latest"
 
 func New(httpClient common.HttpClient, site string) (*Client, error) {
 
@@ -20,114 +21,63 @@ func New(httpClient common.HttpClient, site string) (*Client, error) {
 		httpClient = http.DefaultClient
 	}
 
+	if site == "" {
+		return nil, model.ErrNoSiteError
+	}
+
 	if !strings.HasSuffix(site, "/") {
 		site += "/"
 	}
 
-	siteAsURL, err := url.Parse(site)
+	u, err := url.Parse(site)
 	if err != nil {
 		return nil, err
 	}
 
 	client := &Client{
 		HTTP: httpClient,
-		Site: siteAsURL,
+		Site: u,
 	}
 
 	client.Auth = internal.NewAuthenticationService(client)
+	client.Customer = internal.NewCustomerService(client, defaultServiceManagementVersion)
+	client.Info = internal.NewInfoService(client, defaultServiceManagementVersion)
+	client.Knowledgebase = internal.NewKnowledgebaseService(client, defaultServiceManagementVersion)
+	client.Organization = internal.NewOrganizationService(client, defaultServiceManagementVersion)
 
-	customerService, err := internal.NewCustomerService(client, "latest")
-	if err != nil {
-		return nil, err
-	}
-	client.Customer = customerService
-
-	infoService, err := internal.NewInfoService(client, "latest")
-	if err != nil {
-		return nil, err
-	}
-	client.Info = infoService
-
-	knowledgebaseService, err := internal.NewKnowledgebaseService(client, "latest")
-	if err != nil {
-		return nil, err
-	}
-	client.Knowledgebase = knowledgebaseService
-
-	organizationService, err := internal.NewOrganizationService(client, "latest")
-	if err != nil {
-		return nil, err
-	}
-	client.Organization = organizationService
-
-	commentService, err := internal.NewCommentService(client, "latest")
-	if err != nil {
-		return nil, err
+	requestSubServices := &internal.ServiceRequestSubServices{
+		Approval:    internal.NewApprovalService(client, defaultServiceManagementVersion),
+		Attachment:  internal.NewAttachmentService(client, defaultServiceManagementVersion),
+		Comment:     internal.NewCommentService(client, defaultServiceManagementVersion),
+		Participant: internal.NewParticipantService(client, defaultServiceManagementVersion),
+		SLA:         internal.NewServiceLevelAgreementService(client, defaultServiceManagementVersion),
+		Feedback:    internal.NewFeedbackService(client, defaultServiceManagementVersion),
+		Type:        internal.NewTypeService(client, defaultServiceManagementVersion),
 	}
 
-	attachmentService, err := internal.NewAttachmentService(client, "latest")
-	if err != nil {
-		return nil, err
-	}
-
-	approvalService, err := internal.NewApprovalService(client, "latest")
-	if err != nil {
-		return nil, err
-	}
-
-	participantService, err := internal.NewParticipantService(client, "latest")
-	if err != nil {
-		return nil, err
-	}
-
-	slaService, err := internal.NewServiceLevelAgreementService(client, "latest")
-	if err != nil {
-		return nil, err
-	}
-
-	feedbackService, err := internal.NewFeedbackService(client, "latest")
-	if err != nil {
-		return nil, err
-	}
-
-	requestTypeService, err := internal.NewTypeService(client, "latest")
-	if err != nil {
-		return nil, err
-	}
-
-	requestServices := &internal.ServiceRequestSubServices{
-		Approval:    approvalService,
-		Attachment:  attachmentService,
-		Comment:     commentService,
-		Participant: participantService,
-		SLA:         slaService,
-		Feedback:    feedbackService,
-		Type:        requestTypeService,
-	}
-
-	requestService, err := internal.NewRequestService(client, "latest", requestServices)
+	requestService, err := internal.NewRequestService(client, defaultServiceManagementVersion, requestSubServices)
 	if err != nil {
 		return nil, err
 	}
 	client.Request = requestService
 
-	queueService, err := internal.NewQueueService(client, "latest")
-	if err != nil {
-		return nil, err
-	}
+	serviceDeskService, err := internal.NewServiceDeskService(
+		client,
+		defaultServiceManagementVersion,
+		internal.NewQueueService(client, defaultServiceManagementVersion))
 
-	serviceDeskService, err := internal.NewServiceDeskService(client, "latest", queueService)
 	if err != nil {
 		return nil, err
 	}
 	client.ServiceDesk = serviceDeskService
+
 	return client, nil
 }
 
 type Client struct {
 	HTTP          common.HttpClient
-	Auth          common.Authentication
 	Site          *url.URL
+	Auth          common.Authentication
 	Customer      *internal.CustomerService
 	Info          *internal.InfoService
 	Knowledgebase *internal.KnowledgebaseService
@@ -136,83 +86,63 @@ type Client struct {
 	ServiceDesk   *internal.ServiceDeskService
 }
 
-func (c *Client) NewFormRequest(ctx context.Context, method, apiEndpoint, contentType string, payload io.Reader) (*http.Request, error) {
+func (c *Client) NewRequest(ctx context.Context, method, urlStr, type_ string, body interface{}) (*http.Request, error) {
 
-	relativePath, err := url.Parse(apiEndpoint)
+	rel, err := url.Parse(urlStr)
 	if err != nil {
 		return nil, err
 	}
 
-	var endpoint = c.Site.ResolveReference(relativePath).String()
+	u := c.Site.ResolveReference(rel)
 
-	request, err := http.NewRequestWithContext(ctx, method, endpoint, payload)
+	buf := new(bytes.Buffer)
+	if body != nil {
+		err := json.NewEncoder(buf).Encode(body)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, u.String(), buf)
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Accept", "application/json")
 
-	request.Header.Add("Content-Type", contentType)
-	request.Header.Add("Accept", "application/json")
-	request.Header.Set("X-Atlassian-Token", "no-check")
-
-	if c.Auth.HasBasicAuth() {
-		request.SetBasicAuth(c.Auth.GetBasicAuth())
+	if body != nil && type_ == "" {
+		req.Header.Set("Content-Type", "application/json")
 	}
 
-	if c.Auth.HasUserAgent() {
-		request.Header.Set("User-Agent", c.Auth.GetUserAgent())
-	}
-
-	return request, nil
-}
-
-func (c *Client) NewRequest(ctx context.Context, method, apiEndpoint string, payload io.Reader) (*http.Request, error) {
-
-	relativePath, err := url.Parse(apiEndpoint)
-	if err != nil {
-		return nil, err
-	}
-
-	var endpoint = c.Site.ResolveReference(relativePath).String()
-
-	request, err := http.NewRequestWithContext(ctx, method, endpoint, payload)
-	if err != nil {
-		return nil, err
-	}
-
-	request.Header.Set("Accept", "application/json")
-
-	if payload != nil {
-		request.Header.Set("Content-Type", "application/json")
-	}
-
-	if c.Auth.HasSetExperimentalFlag() {
-		request.Header.Set("X-ExperimentalApi", "opt-in")
+	if body != nil && type_ != "" {
+		req.Header.Set("Content-Type", type_)
 	}
 
 	if c.Auth.HasBasicAuth() {
-		request.SetBasicAuth(c.Auth.GetBasicAuth())
+		req.SetBasicAuth(c.Auth.GetBasicAuth())
 	}
 
 	if c.Auth.HasUserAgent() {
-		request.Header.Set("User-Agent", c.Auth.GetUserAgent())
+		req.Header.Set("User-Agent", c.Auth.GetUserAgent())
 	}
 
-	return request, nil
+	return req, nil
 }
 
-func (c *Client) Call(request *http.Request, structure interface{}) (*models.ResponseScheme, error) {
+func (c *Client) Call(request *http.Request, structure interface{}) (*model.ResponseScheme, error) {
 
 	response, err := c.HTTP.Do(request)
 	if err != nil {
 		return nil, err
 	}
 
-	return c.TransformTheHTTPResponse(response, structure)
+	return c.processResponse(response, structure)
 }
 
-func (c *Client) TransformTheHTTPResponse(response *http.Response, structure interface{}) (*models.ResponseScheme, error) {
+func (c *Client) processResponse(response *http.Response, structure interface{}) (*model.ResponseScheme, error) {
 
-	responseTransformed := &models.ResponseScheme{
+	defer response.Body.Close()
+
+	res := &model.ResponseScheme{
 		Response: response,
 		Code:     response.StatusCode,
 		Endpoint: response.Request.URL.String(),
@@ -221,39 +151,39 @@ func (c *Client) TransformTheHTTPResponse(response *http.Response, structure int
 
 	responseAsBytes, err := io.ReadAll(response.Body)
 	if err != nil {
-		return responseTransformed, err
+		return res, err
 	}
 
-	responseTransformed.Bytes.Write(responseAsBytes)
+	res.Bytes.Write(responseAsBytes)
 
-	var wasSuccess = response.StatusCode >= 200 && response.StatusCode < 300
+	wasSuccess := response.StatusCode >= 200 && response.StatusCode < 300
+
 	if !wasSuccess {
-		return responseTransformed, models.ErrInvalidStatusCodeError
+
+		switch response.StatusCode {
+
+		case http.StatusNotFound:
+			return res, model.ErrNotFound
+
+		case http.StatusUnauthorized:
+			return res, model.ErrUnauthorized
+
+		case http.StatusInternalServerError:
+			return res, model.ErrInternalError
+
+		case http.StatusBadRequest:
+			return res, model.ErrBadRequestError
+
+		default:
+			return res, model.ErrInvalidStatusCodeError
+		}
 	}
 
 	if structure != nil {
 		if err = json.Unmarshal(responseAsBytes, &structure); err != nil {
-			return responseTransformed, err
+			return res, err
 		}
 	}
 
-	return responseTransformed, nil
-}
-
-func (c *Client) TransformStructToReader(structure interface{}) (io.Reader, error) {
-
-	if structure == nil {
-		return nil, models.ErrNilPayloadError
-	}
-
-	if reflect.ValueOf(structure).Type().Kind() == reflect.Struct {
-		return nil, models.ErrNonPayloadPointerError
-	}
-
-	structureAsBodyBytes, err := json.Marshal(structure)
-	if err != nil {
-		return nil, err
-	}
-
-	return bytes.NewReader(structureAsBodyBytes), nil
+	return res, nil
 }

--- a/jira/sm/api_client_impl_test.go
+++ b/jira/sm/api_client_impl_test.go
@@ -242,6 +242,7 @@ func TestClient_NewRequest(t *testing.T) {
 	authMocked := internal.NewAuthenticationService(nil)
 	authMocked.SetBasicAuth("mail", "token")
 	authMocked.SetUserAgent("firefox")
+	authMocked.SetExperimentalFlag()
 
 	siteAsURL, err := url.Parse("https://ctreminiom.atlassian.net")
 	if err != nil {
@@ -360,6 +361,7 @@ func TestClient_NewRequest(t *testing.T) {
 
 				assert.Error(t, err)
 			} else {
+
 				assert.NoError(t, err)
 				assert.NotEqual(t, got, nil)
 			}

--- a/jira/sm/api_client_impl_test.go
+++ b/jira/sm/api_client_impl_test.go
@@ -3,15 +3,13 @@ package sm
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
 	"github.com/ctreminiom/go-atlassian/jira/sm/internal"
-	"github.com/ctreminiom/go-atlassian/pkg/infra/models"
+	model "github.com/ctreminiom/go-atlassian/pkg/infra/models"
 	"github.com/ctreminiom/go-atlassian/service/common"
 	"github.com/ctreminiom/go-atlassian/service/mocks"
 	"github.com/stretchr/testify/assert"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
@@ -22,16 +20,43 @@ func TestClient_Call(t *testing.T) {
 
 	expectedResponse := &http.Response{
 		StatusCode: http.StatusOK,
-		Body:       ioutil.NopCloser(strings.NewReader("Hello, world!")),
+		Body:       io.NopCloser(strings.NewReader("Hello, world!")),
 		Request: &http.Request{
 			Method: http.MethodGet,
 			URL:    &url.URL{},
 		},
 	}
 
-	nonExpectedResponse := &http.Response{
+	badRequestResponse := &http.Response{
 		StatusCode: http.StatusBadRequest,
-		Body:       ioutil.NopCloser(strings.NewReader("Hello, world!")),
+		Body:       io.NopCloser(strings.NewReader("Hello, world!")),
+		Request: &http.Request{
+			Method: http.MethodGet,
+			URL:    &url.URL{},
+		},
+	}
+
+	internalServerResponse := &http.Response{
+		StatusCode: http.StatusInternalServerError,
+		Body:       io.NopCloser(strings.NewReader("Hello, world!")),
+		Request: &http.Request{
+			Method: http.MethodGet,
+			URL:    &url.URL{},
+		},
+	}
+
+	unauthorizedResponse := &http.Response{
+		StatusCode: http.StatusUnauthorized,
+		Body:       io.NopCloser(strings.NewReader("Hello, world!")),
+		Request: &http.Request{
+			Method: http.MethodGet,
+			URL:    &url.URL{},
+		},
+	}
+
+	notFoundResponse := &http.Response{
+		StatusCode: http.StatusNotFound,
+		Body:       io.NopCloser(strings.NewReader("Hello, world!")),
 		Request: &http.Request{
 			Method: http.MethodGet,
 			URL:    &url.URL{},
@@ -39,11 +64,10 @@ func TestClient_Call(t *testing.T) {
 	}
 
 	type fields struct {
-		HTTP           common.HttpClient
-		Site           *url.URL
-		Authentication common.Authentication
+		HTTP common.HttpClient
+		Site *url.URL
+		Auth common.Authentication
 	}
-
 	type args struct {
 		request   *http.Request
 		structure interface{}
@@ -52,9 +76,9 @@ func TestClient_Call(t *testing.T) {
 	testCases := []struct {
 		name    string
 		fields  fields
-		on      func(*fields)
 		args    args
-		want    *models.ResponseScheme
+		on      func(*fields)
+		want    *model.ResponseScheme
 		wantErr bool
 		Err     error
 	}{
@@ -73,7 +97,7 @@ func TestClient_Call(t *testing.T) {
 				request:   nil,
 				structure: nil,
 			},
-			want: &models.ResponseScheme{
+			want: &model.ResponseScheme{
 				Response: expectedResponse,
 				Code:     http.StatusOK,
 				Method:   http.MethodGet,
@@ -83,13 +107,13 @@ func TestClient_Call(t *testing.T) {
 		},
 
 		{
-			name: "when the response status is not valid",
+			name: "when the response status is a bad request",
 			on: func(fields *fields) {
 
 				client := mocks.NewHttpClient(t)
 
 				client.On("Do", (*http.Request)(nil)).
-					Return(nonExpectedResponse, nil)
+					Return(badRequestResponse, nil)
 
 				fields.HTTP = client
 			},
@@ -97,34 +121,92 @@ func TestClient_Call(t *testing.T) {
 				request:   nil,
 				structure: nil,
 			},
-			want: &models.ResponseScheme{
-				Response: nonExpectedResponse,
+			want: &model.ResponseScheme{
+				Response: badRequestResponse,
 				Code:     http.StatusBadRequest,
 				Method:   http.MethodGet,
 				Bytes:    *bytes.NewBufferString("Hello, world!"),
 			},
 			wantErr: true,
-			Err:     models.ErrInvalidStatusCodeError,
+			Err:     model.ErrBadRequestError,
 		},
 
 		{
-			name: "when the http callback cannot be executed",
+			name: "when the response status is an internal service error",
 			on: func(fields *fields) {
 
 				client := mocks.NewHttpClient(t)
 
 				client.On("Do", (*http.Request)(nil)).
-					Return(nil, errors.New("error, unable to execute the http call"))
+					Return(internalServerResponse, nil)
 
 				fields.HTTP = client
 			},
+			args: args{
+				request:   nil,
+				structure: nil,
+			},
+			want: &model.ResponseScheme{
+				Response: internalServerResponse,
+				Code:     http.StatusInternalServerError,
+				Method:   http.MethodGet,
+				Bytes:    *bytes.NewBufferString("Hello, world!"),
+			},
 			wantErr: true,
-			Err:     errors.New("error, unable to execute the http call"),
+			Err:     model.ErrInternalError,
+		},
+
+		{
+			name: "when the response status is a not found",
+			on: func(fields *fields) {
+
+				client := mocks.NewHttpClient(t)
+
+				client.On("Do", (*http.Request)(nil)).
+					Return(notFoundResponse, nil)
+
+				fields.HTTP = client
+			},
+			args: args{
+				request:   nil,
+				structure: nil,
+			},
+			want: &model.ResponseScheme{
+				Response: notFoundResponse,
+				Code:     http.StatusNotFound,
+				Method:   http.MethodGet,
+				Bytes:    *bytes.NewBufferString("Hello, world!"),
+			},
+			wantErr: true,
+			Err:     model.ErrNotFound,
+		},
+
+		{
+			name: "when the response status is unauthorized",
+			on: func(fields *fields) {
+
+				client := mocks.NewHttpClient(t)
+
+				client.On("Do", (*http.Request)(nil)).
+					Return(unauthorizedResponse, nil)
+
+				fields.HTTP = client
+			},
+			args: args{
+				request:   nil,
+				structure: nil,
+			},
+			want: &model.ResponseScheme{
+				Response: unauthorizedResponse,
+				Code:     http.StatusUnauthorized,
+				Method:   http.MethodGet,
+				Bytes:    *bytes.NewBufferString("Hello, world!"),
+			},
+			wantErr: true,
+			Err:     model.ErrUnauthorized,
 		},
 	}
-
 	for _, testCase := range testCases {
-
 		t.Run(testCase.name, func(t *testing.T) {
 
 			if testCase.on != nil {
@@ -134,7 +216,6 @@ func TestClient_Call(t *testing.T) {
 			c := &Client{
 				HTTP: testCase.fields.HTTP,
 				Site: testCase.fields.Site,
-				Auth: testCase.fields.Authentication,
 			}
 
 			got, err := c.Call(testCase.args.request, testCase.args.structure)
@@ -151,376 +232,7 @@ func TestClient_Call(t *testing.T) {
 				assert.NoError(t, err)
 				assert.Equal(t, got, testCase.want)
 			}
-		})
-	}
-}
 
-func TestNewV2(t *testing.T) {
-
-	mockClient, err := New(http.DefaultClient, "https://ctreminiom.atlassian.net")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	mockClient.Auth.SetBasicAuth("test", "test")
-	mockClient.Auth.SetUserAgent("aaa")
-
-	mockClient2, _ := New(nil, " https://zhidao.baidu.com/special/view?id=sd&preview=1")
-
-	type args struct {
-		httpClient common.HttpClient
-		site       string
-	}
-
-	testCases := []struct {
-		name    string
-		args    args
-		on      func(*args)
-		want    *Client
-		wantErr bool
-		Err     error
-	}{
-		{
-			name: "when the parameters are correct",
-			args: args{
-				httpClient: http.DefaultClient,
-				site:       "https://ctreminiom.atlassian.net",
-			},
-			want:    mockClient,
-			wantErr: false,
-		},
-
-		{
-			name: "when the site url is not valid",
-			args: args{
-				httpClient: http.DefaultClient,
-				site:       " https://zhidao.baidu.com/special/view?id=sd&preview=1",
-			},
-			want:    mockClient2,
-			wantErr: true,
-			Err:     errors.New("parse \" https://zhidao.baidu.com/special/view?id=sd&preview=1/\": first path segment in URL cannot contain colon"),
-		},
-	}
-
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-
-			gotClient, err := New(testCase.args.httpClient, testCase.args.site)
-
-			if testCase.wantErr {
-
-				if err != nil {
-					t.Logf("error returned: %v", err.Error())
-				}
-
-				assert.Error(t, err)
-				assert.EqualError(t, err, testCase.Err.Error())
-
-			} else {
-				assert.NoError(t, err)
-				assert.NotEqual(t, gotClient, nil)
-			}
-
-		})
-	}
-}
-
-func TestClient_TransformTheHTTPResponse(t *testing.T) {
-
-	expectedJsonResponse := `
-	{
-	  "id": 4,
-	  "self": "https://ctreminiom.atlassian.net/rest/agile/1.0/board/4",
-	  "name": "KP - Scrum",
-	  "type": "scrum"
-	}`
-
-	expectedResponse := &http.Response{
-		StatusCode: http.StatusOK,
-		Body:       ioutil.NopCloser(strings.NewReader(expectedJsonResponse)),
-		Request: &http.Request{
-			Method: http.MethodGet,
-			URL:    &url.URL{},
-		},
-	}
-
-	type fields struct {
-		HTTP           common.HttpClient
-		Site           *url.URL
-		Authentication common.Authentication
-	}
-
-	type args struct {
-		response  *http.Response
-		structure interface{}
-	}
-
-	testCases := []struct {
-		name    string
-		fields  fields
-		args    args
-		want    *models.ResponseScheme
-		wantErr bool
-		Err     error
-	}{
-		{
-			name:   "when the parameters are correct",
-			fields: fields{},
-			args: args{
-				response:  expectedResponse,
-				structure: models.BoardScheme{},
-			},
-			want: &models.ResponseScheme{
-				Response: expectedResponse,
-				Code:     http.StatusOK,
-				Method:   http.MethodGet,
-				Bytes:    *bytes.NewBufferString(expectedJsonResponse),
-			},
-			wantErr: false,
-		},
-	}
-
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-			c := &Client{
-				HTTP: testCase.fields.HTTP,
-				Site: testCase.fields.Site,
-				Auth: testCase.fields.Authentication,
-			}
-
-			got, err := c.TransformTheHTTPResponse(testCase.args.response, testCase.args.structure)
-
-			if testCase.wantErr {
-
-				if err != nil {
-					t.Logf("error returned: %v", err.Error())
-				}
-
-				assert.Error(t, err)
-				assert.EqualError(t, err, testCase.Err.Error())
-
-			} else {
-				assert.NoError(t, err)
-				assert.NotEqual(t, got, nil)
-			}
-		})
-	}
-}
-
-func TestClient_TransformStructToReader(t *testing.T) {
-
-	expectedBytes, err := json.Marshal(&models.BoardScheme{
-		Name: "BoardConnector Sample",
-		Type: "Scrum",
-	})
-
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	type fields struct {
-		HTTP           common.HttpClient
-		Site           *url.URL
-		Authentication common.Authentication
-	}
-
-	type args struct {
-		structure interface{}
-	}
-
-	testCases := []struct {
-		name    string
-		fields  fields
-		args    args
-		want    io.Reader
-		wantErr bool
-		Err     error
-	}{
-		{
-			name: "when the parameters are correct",
-			args: args{
-				structure: &models.BoardScheme{
-					Name: "BoardConnector Sample",
-					Type: "Scrum",
-				},
-			},
-			want:    bytes.NewReader(expectedBytes),
-			wantErr: false,
-		},
-
-		{
-			name: "when the payload provided is not a pointer",
-			args: args{
-				structure: models.BoardScheme{
-					Name: "BoardConnector Sample",
-					Type: "Scrum",
-				},
-			},
-			want:    bytes.NewReader(expectedBytes),
-			wantErr: true,
-			Err:     models.ErrNonPayloadPointerError,
-		},
-
-		{
-			name: "when the payload is not provided",
-			args: args{
-				structure: nil,
-			},
-			want:    bytes.NewReader(expectedBytes),
-			wantErr: true,
-			Err:     models.ErrNilPayloadError,
-		},
-	}
-
-	for _, testCase := range testCases {
-
-		t.Run(testCase.name, func(t *testing.T) {
-			c := &Client{
-				HTTP: testCase.fields.HTTP,
-				Site: testCase.fields.Site,
-				Auth: testCase.fields.Authentication,
-			}
-
-			got, err := c.TransformStructToReader(testCase.args.structure)
-
-			if testCase.wantErr {
-
-				if err != nil {
-					t.Logf("error returned: %v", err.Error())
-				}
-
-				assert.Error(t, err)
-				assert.EqualError(t, err, testCase.Err.Error())
-
-			} else {
-				assert.NoError(t, err)
-				assert.NotEqual(t, got, nil)
-			}
-		})
-	}
-}
-
-func TestClient_NewFormRequest(t *testing.T) {
-
-	authMocked := internal.NewAuthenticationService(nil)
-	authMocked.SetBasicAuth("mail", "token")
-	authMocked.SetUserAgent("firefox")
-
-	siteAsURL, err := url.Parse("https://ctreminiom.atlassian.net")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	requestMocked, err := http.NewRequestWithContext(context.TODO(),
-		http.MethodGet,
-		"https://ctreminiom.atlassian.net/rest/2/issue/attachment",
-		bytes.NewReader([]byte("Hello World")),
-	)
-
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	requestMocked.Header.Add("Content-Type", "form-type-sample")
-	requestMocked.Header.Add("Accept", "application/json")
-	requestMocked.Header.Set("X-Atlassian-Token", "no-check")
-
-	type fields struct {
-		HTTP common.HttpClient
-		Auth common.Authentication
-		Site *url.URL
-	}
-
-	type args struct {
-		ctx         context.Context
-		method      string
-		apiEndpoint string
-		contentType string
-		payload     io.Reader
-	}
-
-	testCases := []struct {
-		name    string
-		fields  fields
-		args    args
-		want    *http.Request
-		wantErr bool
-	}{
-		{
-			name: "when the parameters are correct",
-			fields: fields{
-				HTTP: http.DefaultClient,
-				Auth: authMocked,
-				Site: siteAsURL,
-			},
-			args: args{
-				ctx:         context.TODO(),
-				method:      http.MethodGet,
-				apiEndpoint: "rest/2/issue/attachment",
-				contentType: "form-type-sample",
-				payload:     bytes.NewReader([]byte("Hello World")),
-			},
-			want:    requestMocked,
-			wantErr: false,
-		},
-
-		{
-			name: "when the url cannot be parsed",
-			fields: fields{
-				HTTP: http.DefaultClient,
-				Auth: internal.NewAuthenticationService(nil),
-				Site: siteAsURL,
-			},
-			args: args{
-				ctx:         context.TODO(),
-				method:      http.MethodGet,
-				apiEndpoint: " https://zhidao.baidu.com/special/view?id=49105a24626975510000&preview=1",
-				contentType: "form-type-sample",
-				payload:     bytes.NewReader([]byte("Hello World")),
-			},
-			want:    nil,
-			wantErr: true,
-		},
-
-		{
-			name: "when the request cannot be created",
-			fields: fields{
-				HTTP: http.DefaultClient,
-				Auth: internal.NewAuthenticationService(nil),
-				Site: siteAsURL,
-			},
-			args: args{
-				ctx:         nil,
-				method:      http.MethodGet,
-				apiEndpoint: "rest/2/issue/attachment",
-				contentType: "form-type-sample",
-				payload:     bytes.NewReader([]byte("Hello World")),
-			},
-			want:    requestMocked,
-			wantErr: true,
-		},
-	}
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-			c := &Client{
-				HTTP: testCase.fields.HTTP,
-				Auth: testCase.fields.Auth,
-				Site: testCase.fields.Site,
-			}
-
-			got, err := c.NewFormRequest(testCase.args.ctx, testCase.args.method, testCase.args.apiEndpoint, testCase.args.contentType, testCase.args.payload)
-
-			if testCase.wantErr {
-
-				if err != nil {
-					t.Logf("error returned: %v", err.Error())
-				}
-
-				assert.Error(t, err)
-			} else {
-				assert.NoError(t, err)
-				assert.NotEqual(t, got, nil)
-			}
 		})
 	}
 }
@@ -556,10 +268,11 @@ func TestClient_NewRequest(t *testing.T) {
 	}
 
 	type args struct {
-		ctx         context.Context
-		method      string
-		apiEndpoint string
-		payload     io.Reader
+		ctx    context.Context
+		method string
+		urlStr string
+		type_  string
+		body   interface{}
 	}
 
 	testCases := []struct {
@@ -577,10 +290,11 @@ func TestClient_NewRequest(t *testing.T) {
 				Site: siteAsURL,
 			},
 			args: args{
-				ctx:         context.TODO(),
-				method:      http.MethodGet,
-				apiEndpoint: "rest/2/issue/attachment",
-				payload:     bytes.NewReader([]byte("Hello World")),
+				ctx:    context.TODO(),
+				method: http.MethodGet,
+				urlStr: "rest/2/issue/attachment",
+				type_:  "",
+				body:   bytes.NewReader([]byte("Hello World")),
 			},
 			want:    requestMocked,
 			wantErr: false,
@@ -594,10 +308,10 @@ func TestClient_NewRequest(t *testing.T) {
 				Site: siteAsURL,
 			},
 			args: args{
-				ctx:         context.TODO(),
-				method:      http.MethodGet,
-				apiEndpoint: " https://zhidao.baidu.com/special/view?id=49105a24626975510000&preview=1",
-				payload:     bytes.NewReader([]byte("Hello World")),
+				ctx:    context.TODO(),
+				method: http.MethodGet,
+				urlStr: " https://zhidao.baidu.com/special/view?id=49105a24626975510000&preview=1",
+				body:   bytes.NewReader([]byte("Hello World")),
 			},
 			want:    nil,
 			wantErr: true,
@@ -611,24 +325,32 @@ func TestClient_NewRequest(t *testing.T) {
 				Site: siteAsURL,
 			},
 			args: args{
-				ctx:         nil,
-				method:      http.MethodGet,
-				apiEndpoint: "rest/2/issue/attachment",
-				payload:     bytes.NewReader([]byte("Hello World")),
+				ctx:    nil,
+				method: http.MethodGet,
+				urlStr: "rest/2/issue/attachment",
+				body:   bytes.NewReader([]byte("Hello World")),
 			},
 			want:    requestMocked,
 			wantErr: true,
 		},
 	}
+
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
+
 			c := &Client{
 				HTTP: testCase.fields.HTTP,
 				Auth: testCase.fields.Auth,
 				Site: testCase.fields.Site,
 			}
 
-			got, err := c.NewRequest(testCase.args.ctx, testCase.args.method, testCase.args.apiEndpoint, testCase.args.payload)
+			got, err := c.NewRequest(
+				testCase.args.ctx,
+				testCase.args.method,
+				testCase.args.urlStr,
+				testCase.args.type_,
+				testCase.args.body,
+			)
 
 			if testCase.wantErr {
 
@@ -640,6 +362,170 @@ func TestClient_NewRequest(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 				assert.NotEqual(t, got, nil)
+			}
+
+		})
+	}
+}
+
+func TestClient_processResponse(t *testing.T) {
+
+	expectedJsonResponse := `
+	{
+	  "id": 4,
+	  "self": "https://ctreminiom.atlassian.net/rest/agile/1.0/board/4",
+	  "name": "KP - Scrum",
+	  "type": "scrum"
+	}`
+
+	expectedResponse := &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(expectedJsonResponse)),
+		Request: &http.Request{
+			Method: http.MethodGet,
+			URL:    &url.URL{},
+		},
+	}
+
+	type fields struct {
+		HTTP           common.HttpClient
+		Site           *url.URL
+		Authentication common.Authentication
+	}
+	type args struct {
+		response  *http.Response
+		structure interface{}
+	}
+
+	testCases := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    *model.ResponseScheme
+		wantErr bool
+		Err     error
+	}{
+		{
+			name:   "when the parameters are correct",
+			fields: fields{},
+			args: args{
+				response:  expectedResponse,
+				structure: model.BoardScheme{},
+			},
+			want: &model.ResponseScheme{
+				Response: expectedResponse,
+				Code:     http.StatusOK,
+				Method:   http.MethodGet,
+				Bytes:    *bytes.NewBufferString(expectedJsonResponse),
+			},
+			wantErr: false,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+
+			c := &Client{
+				HTTP: testCase.fields.HTTP,
+				Site: testCase.fields.Site,
+				Auth: testCase.fields.Authentication,
+			}
+
+			got, err := c.processResponse(testCase.args.response, testCase.args.structure)
+
+			if testCase.wantErr {
+
+				if err != nil {
+					t.Logf("error returned: %v", err.Error())
+				}
+
+				assert.Error(t, err)
+				assert.EqualError(t, err, testCase.Err.Error())
+
+			} else {
+				assert.NoError(t, err)
+				assert.NotEqual(t, got, nil)
+			}
+
+		})
+	}
+}
+
+func TestNew(t *testing.T) {
+
+	mockClient, err := New(http.DefaultClient, "https://ctreminiom.atlassian.net")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mockClient.Auth.SetBasicAuth("test", "test")
+	mockClient.Auth.SetUserAgent("aaa")
+
+	invalidURLClientMocked, _ := New(nil, " https://zhidao.baidu.com/special/view?id=sd&preview=1")
+
+	noURLClientMocked, _ := New(nil, "")
+
+	type args struct {
+		httpClient common.HttpClient
+		site       string
+	}
+
+	testCases := []struct {
+		name    string
+		args    args
+		want    *Client
+		wantErr bool
+		Err     error
+	}{
+
+		{
+			name: "when the parameters are correct",
+			args: args{
+				httpClient: http.DefaultClient,
+				site:       "https://ctreminiom.atlassian.net",
+			},
+			want:    mockClient,
+			wantErr: false,
+		},
+
+		{
+			name: "when the site url are not provided",
+			args: args{
+				httpClient: http.DefaultClient,
+				site:       "",
+			},
+			want:    noURLClientMocked,
+			wantErr: true,
+			Err:     model.ErrNoSiteError,
+		},
+		{
+			name: "when the site url is not valid",
+			args: args{
+				httpClient: http.DefaultClient,
+				site:       " https://zhidao.baidu.com/special/view?id=sd&preview=1",
+			},
+			want:    invalidURLClientMocked,
+			wantErr: true,
+			Err:     errors.New("parse \" https://zhidao.baidu.com/special/view?id=sd&preview=1/\": first path segment in URL cannot contain colon"),
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+
+			gotClient, err := New(testCase.args.httpClient, testCase.args.site)
+
+			if testCase.wantErr {
+
+				if err != nil {
+					t.Logf("error returned: %v", err.Error())
+				}
+
+				assert.Error(t, err)
+				assert.EqualError(t, err, testCase.Err.Error())
+
+			} else {
+				assert.NoError(t, err)
+				assert.NotEqual(t, gotClient, nil)
 			}
 		})
 	}

--- a/jira/sm/internal/approval_impl_test.go
+++ b/jira/sm/internal/approval_impl_test.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	model "github.com/ctreminiom/go-atlassian/pkg/infra/models"
@@ -15,7 +14,7 @@ import (
 func Test_internalServiceRequestApprovalImpl_Gets(t *testing.T) {
 
 	type fields struct {
-		c service.Client
+		c service.Connector
 	}
 
 	type args struct {
@@ -42,12 +41,13 @@ func Test_internalServiceRequestApprovalImpl_Gets(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodGet,
 					"rest/servicedeskapi/request/DUMMY-2/approval?limit=50&start=100",
+					"",
 					nil).
 					Return(&http.Request{}, nil)
 
@@ -70,12 +70,13 @@ func Test_internalServiceRequestApprovalImpl_Gets(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodGet,
 					"rest/servicedeskapi/request/DUMMY-2/approval?limit=50&start=100",
+					"",
 					nil).
 					Return(&http.Request{}, nil)
 
@@ -100,12 +101,13 @@ func Test_internalServiceRequestApprovalImpl_Gets(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodGet,
 					"rest/servicedeskapi/request/DUMMY-2/approval?limit=50&start=100",
+					"",
 					nil).
 					Return(&http.Request{}, errors.New("client: no http request created"))
 
@@ -121,7 +123,7 @@ func Test_internalServiceRequestApprovalImpl_Gets(t *testing.T) {
 				ctx: context.Background(),
 			},
 			on: func(fields *fields) {
-				fields.c = mocks.NewClient(t)
+				fields.c = mocks.NewConnector(t)
 			},
 			Err:     model.ErrNoIssueKeyOrIDError,
 			wantErr: true,
@@ -135,10 +137,9 @@ func Test_internalServiceRequestApprovalImpl_Gets(t *testing.T) {
 				testCase.on(&testCase.fields)
 			}
 
-			smService, err := NewApprovalService(testCase.fields.c, "latest")
-			assert.NoError(t, err)
+			approvalService := NewApprovalService(testCase.fields.c, "latest")
 
-			gotResult, gotResponse, err := smService.Gets(testCase.args.ctx, testCase.args.issueKeyOrID, testCase.args.start,
+			gotResult, gotResponse, err := approvalService.Gets(testCase.args.ctx, testCase.args.issueKeyOrID, testCase.args.start,
 				testCase.args.limit)
 
 			if testCase.wantErr {
@@ -162,7 +163,7 @@ func Test_internalServiceRequestApprovalImpl_Gets(t *testing.T) {
 func Test_internalServiceRequestApprovalImpl_Get(t *testing.T) {
 
 	type fields struct {
-		c service.Client
+		c service.Connector
 	}
 
 	type args struct {
@@ -188,12 +189,13 @@ func Test_internalServiceRequestApprovalImpl_Get(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodGet,
 					"rest/servicedeskapi/request/DUMMY-2/approval/19991",
+					"",
 					nil).
 					Return(&http.Request{}, nil)
 
@@ -215,12 +217,13 @@ func Test_internalServiceRequestApprovalImpl_Get(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodGet,
 					"rest/servicedeskapi/request/DUMMY-2/approval/19991",
+					"",
 					nil).
 					Return(&http.Request{}, nil)
 
@@ -244,12 +247,13 @@ func Test_internalServiceRequestApprovalImpl_Get(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodGet,
 					"rest/servicedeskapi/request/DUMMY-2/approval/19991",
+					"",
 					nil).
 					Return(&http.Request{}, errors.New("client: no http request created"))
 
@@ -265,7 +269,7 @@ func Test_internalServiceRequestApprovalImpl_Get(t *testing.T) {
 				ctx: context.Background(),
 			},
 			on: func(fields *fields) {
-				fields.c = mocks.NewClient(t)
+				fields.c = mocks.NewConnector(t)
 			},
 			Err:     model.ErrNoIssueKeyOrIDError,
 			wantErr: true,
@@ -278,7 +282,7 @@ func Test_internalServiceRequestApprovalImpl_Get(t *testing.T) {
 				issueKeyOrID: "DUMMY-2",
 			},
 			on: func(fields *fields) {
-				fields.c = mocks.NewClient(t)
+				fields.c = mocks.NewConnector(t)
 			},
 			Err:     model.ErrNoApprovalIDError,
 			wantErr: true,
@@ -292,10 +296,9 @@ func Test_internalServiceRequestApprovalImpl_Get(t *testing.T) {
 				testCase.on(&testCase.fields)
 			}
 
-			smService, err := NewApprovalService(testCase.fields.c, "latest")
-			assert.NoError(t, err)
+			approvalService := NewApprovalService(testCase.fields.c, "latest")
 
-			gotResult, gotResponse, err := smService.Get(testCase.args.ctx, testCase.args.issueKeyOrID, testCase.args.approvalID)
+			gotResult, gotResponse, err := approvalService.Get(testCase.args.ctx, testCase.args.issueKeyOrID, testCase.args.approvalID)
 
 			if testCase.wantErr {
 
@@ -317,10 +320,8 @@ func Test_internalServiceRequestApprovalImpl_Get(t *testing.T) {
 
 func Test_internalServiceRequestApprovalImpl_Answer(t *testing.T) {
 
-	payloadMocked := &map[string]interface{}{"decision": "approve"}
-
 	type fields struct {
-		c service.Client
+		c service.Connector
 	}
 
 	type args struct {
@@ -348,17 +349,14 @@ func Test_internalServiceRequestApprovalImpl_Answer(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
-
-				client.On("TransformStructToReader",
-					payloadMocked).
-					Return(bytes.NewReader([]byte{}), nil)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodPost,
 					"rest/servicedeskapi/request/DUMMY-2/approval/19991",
-					bytes.NewReader([]byte{})).
+					"",
+					map[string]interface{}{"decision": "approve"}).
 					Return(&http.Request{}, nil)
 
 				client.On("Call",
@@ -380,17 +378,14 @@ func Test_internalServiceRequestApprovalImpl_Answer(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
-
-				client.On("TransformStructToReader",
-					payloadMocked).
-					Return(bytes.NewReader([]byte{}), nil)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodPost,
 					"rest/servicedeskapi/request/DUMMY-2/approval/19991",
-					bytes.NewReader([]byte{})).
+					"",
+					map[string]interface{}{"decision": "approve"}).
 					Return(&http.Request{}, nil)
 
 				client.On("Call",
@@ -414,17 +409,14 @@ func Test_internalServiceRequestApprovalImpl_Answer(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
-
-				client.On("TransformStructToReader",
-					payloadMocked).
-					Return(bytes.NewReader([]byte{}), nil)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodPost,
 					"rest/servicedeskapi/request/DUMMY-2/approval/19991",
-					bytes.NewReader([]byte{})).
+					"",
+					map[string]interface{}{"decision": "approve"}).
 					Return(&http.Request{}, errors.New("client: no http request created"))
 
 				fields.c = client
@@ -439,7 +431,7 @@ func Test_internalServiceRequestApprovalImpl_Answer(t *testing.T) {
 				ctx: context.Background(),
 			},
 			on: func(fields *fields) {
-				fields.c = mocks.NewClient(t)
+				fields.c = mocks.NewConnector(t)
 			},
 			Err:     model.ErrNoIssueKeyOrIDError,
 			wantErr: true,
@@ -452,7 +444,7 @@ func Test_internalServiceRequestApprovalImpl_Answer(t *testing.T) {
 				issueKeyOrID: "DUMMY-2",
 			},
 			on: func(fields *fields) {
-				fields.c = mocks.NewClient(t)
+				fields.c = mocks.NewConnector(t)
 			},
 			Err:     model.ErrNoApprovalIDError,
 			wantErr: true,
@@ -466,10 +458,9 @@ func Test_internalServiceRequestApprovalImpl_Answer(t *testing.T) {
 				testCase.on(&testCase.fields)
 			}
 
-			smService, err := NewApprovalService(testCase.fields.c, "latest")
-			assert.NoError(t, err)
+			approvalService := NewApprovalService(testCase.fields.c, "latest")
 
-			gotResult, gotResponse, err := smService.Answer(testCase.args.ctx, testCase.args.issueKeyOrID,
+			gotResult, gotResponse, err := approvalService.Answer(testCase.args.ctx, testCase.args.issueKeyOrID,
 				testCase.args.approvalID, testCase.args.approve)
 
 			if testCase.wantErr {

--- a/jira/sm/internal/attachment_impl_test.go
+++ b/jira/sm/internal/attachment_impl_test.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	model "github.com/ctreminiom/go-atlassian/pkg/infra/models"
@@ -15,7 +14,7 @@ import (
 func Test_internalServiceRequestAttachmentImpl_Gets(t *testing.T) {
 
 	type fields struct {
-		c service.Client
+		c service.Connector
 	}
 
 	type args struct {
@@ -42,12 +41,13 @@ func Test_internalServiceRequestAttachmentImpl_Gets(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodGet,
 					"rest/servicedeskapi/request/DUMMY-2/attachment?limit=50&start=100",
+					"",
 					nil).
 					Return(&http.Request{}, nil)
 
@@ -70,12 +70,13 @@ func Test_internalServiceRequestAttachmentImpl_Gets(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodGet,
 					"rest/servicedeskapi/request/DUMMY-2/attachment?limit=50&start=100",
+					"",
 					nil).
 					Return(&http.Request{}, nil)
 
@@ -100,12 +101,13 @@ func Test_internalServiceRequestAttachmentImpl_Gets(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodGet,
 					"rest/servicedeskapi/request/DUMMY-2/attachment?limit=50&start=100",
+					"",
 					nil).
 					Return(&http.Request{}, errors.New("client: no http request created"))
 
@@ -121,7 +123,7 @@ func Test_internalServiceRequestAttachmentImpl_Gets(t *testing.T) {
 				ctx: context.Background(),
 			},
 			on: func(fields *fields) {
-				fields.c = mocks.NewClient(t)
+				fields.c = mocks.NewConnector(t)
 			},
 			Err:     model.ErrNoIssueKeyOrIDError,
 			wantErr: true,
@@ -135,10 +137,9 @@ func Test_internalServiceRequestAttachmentImpl_Gets(t *testing.T) {
 				testCase.on(&testCase.fields)
 			}
 
-			smService, err := NewAttachmentService(testCase.fields.c, "latest")
-			assert.NoError(t, err)
+			attachmentService := NewAttachmentService(testCase.fields.c, "latest")
 
-			gotResult, gotResponse, err := smService.Gets(testCase.args.ctx, testCase.args.issueKeyOrID, testCase.args.start,
+			gotResult, gotResponse, err := attachmentService.Gets(testCase.args.ctx, testCase.args.issueKeyOrID, testCase.args.start,
 				testCase.args.limit)
 
 			if testCase.wantErr {
@@ -161,13 +162,8 @@ func Test_internalServiceRequestAttachmentImpl_Gets(t *testing.T) {
 
 func Test_internalServiceRequestAttachmentImpl_Create(t *testing.T) {
 
-	payloadMocked := &struct {
-		TemporaryAttachmentIds []string "json:\"temporaryAttachmentIds,omitempty\""
-		Public                 bool     "json:\"public,omitempty\""
-	}{TemporaryAttachmentIds: []string{"10001"}, Public: true}
-
 	type fields struct {
-		c service.Client
+		c service.Connector
 	}
 
 	type args struct {
@@ -195,17 +191,14 @@ func Test_internalServiceRequestAttachmentImpl_Create(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
-
-				client.On("TransformStructToReader",
-					payloadMocked).
-					Return(bytes.NewReader([]byte{}), nil)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodPost,
 					"rest/servicedeskapi/request/DUMMY-2/attachment",
-					bytes.NewReader([]byte{})).
+					"",
+					map[string]interface{}{"public": true, "temporaryAttachmentIds": []string{"10001"}}).
 					Return(&http.Request{}, nil)
 
 				client.On("Call",
@@ -227,17 +220,14 @@ func Test_internalServiceRequestAttachmentImpl_Create(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
-
-				client.On("TransformStructToReader",
-					payloadMocked).
-					Return(bytes.NewReader([]byte{}), nil)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodPost,
 					"rest/servicedeskapi/request/DUMMY-2/attachment",
-					bytes.NewReader([]byte{})).
+					"",
+					map[string]interface{}{"public": true, "temporaryAttachmentIds": []string{"10001"}}).
 					Return(&http.Request{}, nil)
 
 				client.On("Call",
@@ -261,17 +251,14 @@ func Test_internalServiceRequestAttachmentImpl_Create(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
-
-				client.On("TransformStructToReader",
-					payloadMocked).
-					Return(bytes.NewReader([]byte{}), nil)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodPost,
 					"rest/servicedeskapi/request/DUMMY-2/attachment",
-					bytes.NewReader([]byte{})).
+					"",
+					map[string]interface{}{"public": true, "temporaryAttachmentIds": []string{"10001"}}).
 					Return(&http.Request{}, errors.New("client: no http request created"))
 
 				fields.c = client
@@ -286,7 +273,7 @@ func Test_internalServiceRequestAttachmentImpl_Create(t *testing.T) {
 				ctx: context.Background(),
 			},
 			on: func(fields *fields) {
-				fields.c = mocks.NewClient(t)
+				fields.c = mocks.NewConnector(t)
 			},
 			Err:     model.ErrNoIssueKeyOrIDError,
 			wantErr: true,
@@ -300,10 +287,9 @@ func Test_internalServiceRequestAttachmentImpl_Create(t *testing.T) {
 				testCase.on(&testCase.fields)
 			}
 
-			smService, err := NewAttachmentService(testCase.fields.c, "latest")
-			assert.NoError(t, err)
+			attachmentService := NewAttachmentService(testCase.fields.c, "latest")
 
-			gotResult, gotResponse, err := smService.Create(testCase.args.ctx, testCase.args.issueKeyOrID,
+			gotResult, gotResponse, err := attachmentService.Create(testCase.args.ctx, testCase.args.issueKeyOrID,
 				testCase.args.temporaryAttachmentIDs, testCase.args.public)
 
 			if testCase.wantErr {

--- a/jira/sm/internal/authentication_impl.go
+++ b/jira/sm/internal/authentication_impl.go
@@ -5,20 +5,18 @@ import (
 	"github.com/ctreminiom/go-atlassian/service/common"
 )
 
-func NewAuthenticationService(client service.Client) common.Authentication {
+func NewAuthenticationService(client service.Connector) common.Authentication {
 	return &AuthenticationService{c: client}
 }
 
 type AuthenticationService struct {
-	c service.Client
+	c service.Connector
 
 	basicAuthProvided bool
 	mail, token       string
 
 	userAgentProvided bool
 	agent             string
-
-	experimentalProvided bool
 }
 
 func (a *AuthenticationService) SetBearerToken(token string) {
@@ -28,13 +26,10 @@ func (a *AuthenticationService) SetBearerToken(token string) {
 func (a *AuthenticationService) GetBearerToken() string {
 	return a.token
 }
-
-func (a *AuthenticationService) SetExperimentalFlag() {
-	a.experimentalProvided = true
-}
+func (a *AuthenticationService) SetExperimentalFlag() {}
 
 func (a *AuthenticationService) HasSetExperimentalFlag() bool {
-	return a.experimentalProvided
+	return false
 }
 
 func (a *AuthenticationService) SetBasicAuth(mail, token string) {

--- a/jira/sm/internal/authentication_impl.go
+++ b/jira/sm/internal/authentication_impl.go
@@ -17,6 +17,8 @@ type AuthenticationService struct {
 
 	userAgentProvided bool
 	agent             string
+
+	experimentalFlagSet bool
 }
 
 func (a *AuthenticationService) SetBearerToken(token string) {
@@ -26,10 +28,12 @@ func (a *AuthenticationService) SetBearerToken(token string) {
 func (a *AuthenticationService) GetBearerToken() string {
 	return a.token
 }
-func (a *AuthenticationService) SetExperimentalFlag() {}
+func (a *AuthenticationService) SetExperimentalFlag() {
+	a.experimentalFlagSet = true
+}
 
 func (a *AuthenticationService) HasSetExperimentalFlag() bool {
-	return false
+	return a.experimentalFlagSet
 }
 
 func (a *AuthenticationService) SetBasicAuth(mail, token string) {

--- a/jira/sm/internal/authentication_impl_test.go
+++ b/jira/sm/internal/authentication_impl_test.go
@@ -12,7 +12,7 @@ import (
 func TestAuthenticationService_GetBasicAuth(t *testing.T) {
 
 	type fields struct {
-		c                 service.Client
+		c                 service.Connector
 		basicAuthProvided bool
 		mail              string
 		token             string
@@ -28,7 +28,7 @@ func TestAuthenticationService_GetBasicAuth(t *testing.T) {
 		{
 			name: "when the basic auth is already set",
 			fields: fields{
-				c:     mocks.NewClient(t),
+				c:     mocks.NewConnector(t),
 				mail:  "mail",
 				token: "token",
 			},
@@ -62,7 +62,7 @@ func TestAuthenticationService_GetBasicAuth(t *testing.T) {
 
 func TestAuthenticationService_GetUserAgent(t *testing.T) {
 	type fields struct {
-		c                 service.Client
+		c                 service.Connector
 		basicAuthProvided bool
 		mail              string
 		token             string
@@ -77,7 +77,7 @@ func TestAuthenticationService_GetUserAgent(t *testing.T) {
 		{
 			name: "when the user agent is already set",
 			fields: fields{
-				c:     mocks.NewClient(t),
+				c:     mocks.NewConnector(t),
 				agent: "firefox-09",
 			},
 			want: "firefox-09",
@@ -102,7 +102,7 @@ func TestAuthenticationService_GetUserAgent(t *testing.T) {
 
 func TestAuthenticationService_HasBasicAuth(t *testing.T) {
 	type fields struct {
-		c                 service.Client
+		c                 service.Connector
 		basicAuthProvided bool
 		mail              string
 		token             string
@@ -117,7 +117,7 @@ func TestAuthenticationService_HasBasicAuth(t *testing.T) {
 		{
 			name: "when the params are correct",
 			fields: fields{
-				c:                 mocks.NewClient(t),
+				c:                 mocks.NewConnector(t),
 				basicAuthProvided: true,
 			},
 			want: true,
@@ -143,7 +143,7 @@ func TestAuthenticationService_HasBasicAuth(t *testing.T) {
 
 func TestAuthenticationService_HasUserAgent(t *testing.T) {
 	type fields struct {
-		c                 service.Client
+		c                 service.Connector
 		basicAuthProvided bool
 		mail              string
 		token             string
@@ -184,10 +184,10 @@ func TestAuthenticationService_HasUserAgent(t *testing.T) {
 
 func TestNewAuthenticationService(t *testing.T) {
 
-	clientMocked := mocks.NewClient(t)
+	clientMocked := mocks.NewConnector(t)
 
 	type args struct {
-		client service.Client
+		client service.Connector
 	}
 	testCases := []struct {
 		name string
@@ -214,7 +214,7 @@ func TestNewAuthenticationService(t *testing.T) {
 func TestAuthenticationService_SetUserAgent(t *testing.T) {
 
 	type fields struct {
-		c                 service.Client
+		c                 service.Connector
 		basicAuthProvided bool
 		mail              string
 		token             string
@@ -254,7 +254,7 @@ func TestAuthenticationService_SetUserAgent(t *testing.T) {
 func TestAuthenticationService_SetBasicAuth(t *testing.T) {
 
 	type fields struct {
-		c                 service.Client
+		c                 service.Connector
 		basicAuthProvided bool
 		mail              string
 		token             string
@@ -297,7 +297,7 @@ func TestAuthenticationService_SetBasicAuth(t *testing.T) {
 func TestAuthenticationService_HasSetExperimentalFlag(t *testing.T) {
 
 	type fields struct {
-		c                 service.Client
+		c                 service.Connector
 		basicAuthProvided bool
 		mail              string
 		token             string
@@ -335,7 +335,7 @@ func TestAuthenticationService_HasSetExperimentalFlag(t *testing.T) {
 
 func TestAuthenticationService_GetBearerToken(t *testing.T) {
 	type fields struct {
-		c                 service.Client
+		c                 service.Connector
 		basicAuthProvided bool
 		mail              string
 		token             string
@@ -350,7 +350,7 @@ func TestAuthenticationService_GetBearerToken(t *testing.T) {
 		{
 			name: "when the parameters are correct",
 			fields: fields{
-				c:     mocks.NewClient(t),
+				c:     mocks.NewConnector(t),
 				token: "token-sample",
 			},
 			want: "token-sample",
@@ -373,7 +373,7 @@ func TestAuthenticationService_GetBearerToken(t *testing.T) {
 
 func TestAuthenticationService_SetBearerToken(t *testing.T) {
 	type fields struct {
-		c                 service.Client
+		c                 service.Connector
 		basicAuthProvided bool
 		mail              string
 		token             string
@@ -415,7 +415,7 @@ func TestAuthenticationService_SetBearerToken(t *testing.T) {
 
 func TestAuthenticationService_SetExperimentalFlag(t *testing.T) {
 	type fields struct {
-		c                 service.Client
+		c                 service.Connector
 		basicAuthProvided bool
 		mail              string
 		token             string

--- a/jira/sm/internal/comment_impl_test.go
+++ b/jira/sm/internal/comment_impl_test.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	model "github.com/ctreminiom/go-atlassian/pkg/infra/models"
@@ -15,7 +14,7 @@ import (
 func Test_internalServiceRequestCommentImpl_Gets(t *testing.T) {
 
 	type fields struct {
-		c service.Client
+		c service.Connector
 	}
 
 	type args struct {
@@ -46,12 +45,13 @@ func Test_internalServiceRequestCommentImpl_Gets(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodGet,
 					"rest/servicedeskapi/request/DUMMY-2/comment?expand=attachment&limit=50&start=100",
+					"",
 					nil).
 					Return(&http.Request{}, nil)
 
@@ -76,12 +76,13 @@ func Test_internalServiceRequestCommentImpl_Gets(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodGet,
 					"rest/servicedeskapi/request/DUMMY-2/comment?expand=attachment&limit=50&start=100",
+					"",
 					nil).
 					Return(&http.Request{}, nil)
 
@@ -108,12 +109,13 @@ func Test_internalServiceRequestCommentImpl_Gets(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodGet,
 					"rest/servicedeskapi/request/DUMMY-2/comment?expand=attachment&limit=50&start=100",
+					"",
 					nil).
 					Return(&http.Request{}, errors.New("client: no http request created"))
 
@@ -129,7 +131,7 @@ func Test_internalServiceRequestCommentImpl_Gets(t *testing.T) {
 				ctx: context.Background(),
 			},
 			on: func(fields *fields) {
-				fields.c = mocks.NewClient(t)
+				fields.c = mocks.NewConnector(t)
 			},
 			Err:     model.ErrNoIssueKeyOrIDError,
 			wantErr: true,
@@ -143,10 +145,9 @@ func Test_internalServiceRequestCommentImpl_Gets(t *testing.T) {
 				testCase.on(&testCase.fields)
 			}
 
-			smService, err := NewCommentService(testCase.fields.c, "latest")
-			assert.NoError(t, err)
+			commentService := NewCommentService(testCase.fields.c, "latest")
 
-			gotResult, gotResponse, err := smService.Gets(testCase.args.ctx, testCase.args.issueKeyOrID, testCase.args.public,
+			gotResult, gotResponse, err := commentService.Gets(testCase.args.ctx, testCase.args.issueKeyOrID, testCase.args.public,
 				testCase.args.expand, testCase.args.start,
 				testCase.args.limit)
 
@@ -171,7 +172,7 @@ func Test_internalServiceRequestCommentImpl_Gets(t *testing.T) {
 func Test_internalServiceRequestCommentImpl_Get(t *testing.T) {
 
 	type fields struct {
-		c service.Client
+		c service.Connector
 	}
 
 	type args struct {
@@ -199,12 +200,13 @@ func Test_internalServiceRequestCommentImpl_Get(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodGet,
 					"rest/servicedeskapi/request/DUMMY-2/comment/10001?expand=attachment",
+					"",
 					nil).
 					Return(&http.Request{}, nil)
 
@@ -227,12 +229,13 @@ func Test_internalServiceRequestCommentImpl_Get(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodGet,
 					"rest/servicedeskapi/request/DUMMY-2/comment/10001?expand=attachment",
+					"",
 					nil).
 					Return(&http.Request{}, nil)
 
@@ -257,12 +260,13 @@ func Test_internalServiceRequestCommentImpl_Get(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodGet,
 					"rest/servicedeskapi/request/DUMMY-2/comment/10001?expand=attachment",
+					"",
 					nil).
 					Return(&http.Request{}, errors.New("client: no http request created"))
 
@@ -278,7 +282,7 @@ func Test_internalServiceRequestCommentImpl_Get(t *testing.T) {
 				ctx: context.Background(),
 			},
 			on: func(fields *fields) {
-				fields.c = mocks.NewClient(t)
+				fields.c = mocks.NewConnector(t)
 			},
 			Err:     model.ErrNoIssueKeyOrIDError,
 			wantErr: true,
@@ -291,7 +295,7 @@ func Test_internalServiceRequestCommentImpl_Get(t *testing.T) {
 				issueKeyOrID: "DUMMY-2",
 			},
 			on: func(fields *fields) {
-				fields.c = mocks.NewClient(t)
+				fields.c = mocks.NewConnector(t)
 			},
 			Err:     model.ErrNoCommentIDError,
 			wantErr: true,
@@ -305,10 +309,9 @@ func Test_internalServiceRequestCommentImpl_Get(t *testing.T) {
 				testCase.on(&testCase.fields)
 			}
 
-			smService, err := NewCommentService(testCase.fields.c, "latest")
-			assert.NoError(t, err)
+			commentService := NewCommentService(testCase.fields.c, "latest")
 
-			gotResult, gotResponse, err := smService.Get(testCase.args.ctx, testCase.args.issueKeyOrID, testCase.args.commentID,
+			gotResult, gotResponse, err := commentService.Get(testCase.args.ctx, testCase.args.issueKeyOrID, testCase.args.commentID,
 				testCase.args.expand)
 
 			if testCase.wantErr {
@@ -331,13 +334,8 @@ func Test_internalServiceRequestCommentImpl_Get(t *testing.T) {
 
 func Test_internalServiceRequestCommentImpl_Create(t *testing.T) {
 
-	payloadMocked := &struct {
-		Public bool   "json:\"public\""
-		Body   string "json:\"body\""
-	}{Public: true, Body: "*body sample*"}
-
 	type fields struct {
-		c service.Client
+		c service.Connector
 	}
 
 	type args struct {
@@ -364,17 +362,14 @@ func Test_internalServiceRequestCommentImpl_Create(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
-
-				client.On("TransformStructToReader",
-					payloadMocked).
-					Return(bytes.NewReader([]byte{}), nil)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodPost,
 					"rest/servicedeskapi/request/DUMMY-2/comment",
-					bytes.NewReader([]byte{})).
+					"",
+					map[string]interface{}{"body": "*body sample*", "public": true}).
 					Return(&http.Request{}, nil)
 
 				client.On("Call",
@@ -396,17 +391,14 @@ func Test_internalServiceRequestCommentImpl_Create(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
-
-				client.On("TransformStructToReader",
-					payloadMocked).
-					Return(bytes.NewReader([]byte{}), nil)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodPost,
 					"rest/servicedeskapi/request/DUMMY-2/comment",
-					bytes.NewReader([]byte{})).
+					"",
+					map[string]interface{}{"body": "*body sample*", "public": true}).
 					Return(&http.Request{}, nil)
 
 				client.On("Call",
@@ -430,17 +422,14 @@ func Test_internalServiceRequestCommentImpl_Create(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
-
-				client.On("TransformStructToReader",
-					payloadMocked).
-					Return(bytes.NewReader([]byte{}), nil)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodPost,
 					"rest/servicedeskapi/request/DUMMY-2/comment",
-					bytes.NewReader([]byte{})).
+					"",
+					map[string]interface{}{"body": "*body sample*", "public": true}).
 					Return(&http.Request{}, errors.New("client: no http request created"))
 
 				fields.c = client
@@ -455,7 +444,7 @@ func Test_internalServiceRequestCommentImpl_Create(t *testing.T) {
 				ctx: context.Background(),
 			},
 			on: func(fields *fields) {
-				fields.c = mocks.NewClient(t)
+				fields.c = mocks.NewConnector(t)
 			},
 			Err:     model.ErrNoIssueKeyOrIDError,
 			wantErr: true,
@@ -468,7 +457,7 @@ func Test_internalServiceRequestCommentImpl_Create(t *testing.T) {
 				issueKeyOrID: "DUMMY-2",
 			},
 			on: func(fields *fields) {
-				fields.c = mocks.NewClient(t)
+				fields.c = mocks.NewConnector(t)
 			},
 			Err:     model.ErrNoCommentBodyError,
 			wantErr: true,
@@ -482,10 +471,9 @@ func Test_internalServiceRequestCommentImpl_Create(t *testing.T) {
 				testCase.on(&testCase.fields)
 			}
 
-			smService, err := NewCommentService(testCase.fields.c, "latest")
-			assert.NoError(t, err)
+			commentService := NewCommentService(testCase.fields.c, "latest")
 
-			gotResult, gotResponse, err := smService.Create(testCase.args.ctx, testCase.args.issueKeyOrID, testCase.args.body,
+			gotResult, gotResponse, err := commentService.Create(testCase.args.ctx, testCase.args.issueKeyOrID, testCase.args.body,
 				testCase.args.public)
 
 			if testCase.wantErr {
@@ -509,7 +497,7 @@ func Test_internalServiceRequestCommentImpl_Create(t *testing.T) {
 func Test_internalServiceRequestCommentImpl_Attachments(t *testing.T) {
 
 	type fields struct {
-		c service.Client
+		c service.Connector
 	}
 
 	type args struct {
@@ -537,12 +525,13 @@ func Test_internalServiceRequestCommentImpl_Attachments(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodGet,
 					"rest/servicedeskapi/request/DUMMY-2/comment/10001/attachment?limit=50&start=100",
+					"",
 					nil).
 					Return(&http.Request{}, nil)
 
@@ -566,12 +555,13 @@ func Test_internalServiceRequestCommentImpl_Attachments(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodGet,
 					"rest/servicedeskapi/request/DUMMY-2/comment/10001/attachment?limit=50&start=100",
+					"",
 					nil).
 					Return(&http.Request{}, nil)
 
@@ -597,12 +587,13 @@ func Test_internalServiceRequestCommentImpl_Attachments(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodGet,
 					"rest/servicedeskapi/request/DUMMY-2/comment/10001/attachment?limit=50&start=100",
+					"",
 					nil).
 					Return(&http.Request{}, errors.New("client: no http request created"))
 
@@ -618,7 +609,7 @@ func Test_internalServiceRequestCommentImpl_Attachments(t *testing.T) {
 				ctx: context.Background(),
 			},
 			on: func(fields *fields) {
-				fields.c = mocks.NewClient(t)
+				fields.c = mocks.NewConnector(t)
 			},
 			Err:     model.ErrNoIssueKeyOrIDError,
 			wantErr: true,
@@ -632,10 +623,9 @@ func Test_internalServiceRequestCommentImpl_Attachments(t *testing.T) {
 				testCase.on(&testCase.fields)
 			}
 
-			smService, err := NewCommentService(testCase.fields.c, "latest")
-			assert.NoError(t, err)
+			commentService := NewCommentService(testCase.fields.c, "latest")
 
-			gotResult, gotResponse, err := smService.Attachments(testCase.args.ctx, testCase.args.issueKeyOrID, testCase.args.commentID,
+			gotResult, gotResponse, err := commentService.Attachments(testCase.args.ctx, testCase.args.issueKeyOrID, testCase.args.commentID,
 				testCase.args.start, testCase.args.limit)
 
 			if testCase.wantErr {

--- a/jira/sm/internal/customer_impl_test.go
+++ b/jira/sm/internal/customer_impl_test.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	model "github.com/ctreminiom/go-atlassian/pkg/infra/models"
@@ -14,13 +13,8 @@ import (
 
 func Test_internalCustomerImpl_Create(t *testing.T) {
 
-	payloadMocked := &struct {
-		DisplayName string "json:\"displayName,omitempty\""
-		Email       string "json:\"email,omitempty\""
-	}{DisplayName: "Carlos T", Email: "carlos.treminio@example.com"}
-
 	type fields struct {
-		c service.Client
+		c service.Connector
 	}
 
 	type args struct {
@@ -45,17 +39,14 @@ func Test_internalCustomerImpl_Create(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
-
-				client.On("TransformStructToReader",
-					payloadMocked).
-					Return(bytes.NewReader([]byte{}), nil)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodPost,
 					"rest/servicedeskapi/customer",
-					bytes.NewReader([]byte{})).
+					"",
+					map[string]interface{}{"displayName": "Carlos T", "email": "carlos.treminio@example.com"}).
 					Return(&http.Request{}, nil)
 
 				client.On("Call",
@@ -76,17 +67,14 @@ func Test_internalCustomerImpl_Create(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
-
-				client.On("TransformStructToReader",
-					payloadMocked).
-					Return(bytes.NewReader([]byte{}), nil)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodPost,
 					"rest/servicedeskapi/customer",
-					bytes.NewReader([]byte{})).
+					"",
+					map[string]interface{}{"displayName": "Carlos T", "email": "carlos.treminio@example.com"}).
 					Return(&http.Request{}, nil)
 
 				client.On("Call",
@@ -109,17 +97,14 @@ func Test_internalCustomerImpl_Create(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
-
-				client.On("TransformStructToReader",
-					payloadMocked).
-					Return(bytes.NewReader([]byte{}), nil)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodPost,
 					"rest/servicedeskapi/customer",
-					bytes.NewReader([]byte{})).
+					"",
+					map[string]interface{}{"displayName": "Carlos T", "email": "carlos.treminio@example.com"}).
 					Return(&http.Request{}, errors.New("client: no http request created"))
 
 				fields.c = client
@@ -136,10 +121,9 @@ func Test_internalCustomerImpl_Create(t *testing.T) {
 				testCase.on(&testCase.fields)
 			}
 
-			smService, err := NewCustomerService(testCase.fields.c, "latest")
-			assert.NoError(t, err)
+			customerService := NewCustomerService(testCase.fields.c, "latest")
 
-			gotResult, gotResponse, err := smService.Create(testCase.args.ctx, testCase.args.email, testCase.args.displayName)
+			gotResult, gotResponse, err := customerService.Create(testCase.args.ctx, testCase.args.email, testCase.args.displayName)
 
 			if testCase.wantErr {
 
@@ -162,7 +146,7 @@ func Test_internalCustomerImpl_Create(t *testing.T) {
 func Test_internalCustomerImpl_Gets(t *testing.T) {
 
 	type fields struct {
-		c service.Client
+		c service.Connector
 	}
 
 	type args struct {
@@ -191,12 +175,13 @@ func Test_internalCustomerImpl_Gets(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodGet,
 					"rest/servicedeskapi/servicedesk/10001/customer?limit=50&query=Carlos+T&start=100",
+					"",
 					nil).
 					Return(&http.Request{}, nil)
 
@@ -220,12 +205,13 @@ func Test_internalCustomerImpl_Gets(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodGet,
 					"rest/servicedeskapi/servicedesk/10001/customer?limit=50&query=Carlos+T&start=100",
+					"",
 					nil).
 					Return(&http.Request{}, nil)
 
@@ -251,12 +237,13 @@ func Test_internalCustomerImpl_Gets(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodGet,
 					"rest/servicedeskapi/servicedesk/10001/customer?limit=50&query=Carlos+T&start=100",
+					"",
 					nil).
 					Return(&http.Request{}, errors.New("client: no http request created"))
 
@@ -274,10 +261,9 @@ func Test_internalCustomerImpl_Gets(t *testing.T) {
 				testCase.on(&testCase.fields)
 			}
 
-			smService, err := NewCustomerService(testCase.fields.c, "latest")
-			assert.NoError(t, err)
+			customerService := NewCustomerService(testCase.fields.c, "latest")
 
-			gotResult, gotResponse, err := smService.Gets(testCase.args.ctx, testCase.args.serviceDeskID, testCase.args.query,
+			gotResult, gotResponse, err := customerService.Gets(testCase.args.ctx, testCase.args.serviceDeskID, testCase.args.query,
 				testCase.args.start, testCase.args.limit)
 
 			if testCase.wantErr {
@@ -300,12 +286,8 @@ func Test_internalCustomerImpl_Gets(t *testing.T) {
 
 func Test_internalCustomerImpl_Add(t *testing.T) {
 
-	payloadMocked := &struct {
-		AccountIds []string "json:\"accountIds\""
-	}{AccountIds: []string{"uuid-sample-1", "uuid-sample-2"}}
-
 	type fields struct {
-		c service.Client
+		c service.Connector
 	}
 
 	type args struct {
@@ -331,17 +313,14 @@ func Test_internalCustomerImpl_Add(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
-
-				client.On("TransformStructToReader",
-					payloadMocked).
-					Return(bytes.NewReader([]byte{}), nil)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodPost,
 					"rest/servicedeskapi/servicedesk/10001/customer",
-					bytes.NewReader([]byte{})).
+					"",
+					map[string]interface{}{"accountIds": []string{"uuid-sample-1", "uuid-sample-2"}}).
 					Return(&http.Request{}, nil)
 
 				client.On("Call",
@@ -362,17 +341,14 @@ func Test_internalCustomerImpl_Add(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
-
-				client.On("TransformStructToReader",
-					payloadMocked).
-					Return(bytes.NewReader([]byte{}), nil)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodPost,
 					"rest/servicedeskapi/servicedesk/10001/customer",
-					bytes.NewReader([]byte{})).
+					"",
+					map[string]interface{}{"accountIds": []string{"uuid-sample-1", "uuid-sample-2"}}).
 					Return(&http.Request{}, nil)
 
 				client.On("Call",
@@ -395,17 +371,14 @@ func Test_internalCustomerImpl_Add(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
-
-				client.On("TransformStructToReader",
-					payloadMocked).
-					Return(bytes.NewReader([]byte{}), nil)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodPost,
 					"rest/servicedeskapi/servicedesk/10001/customer",
-					bytes.NewReader([]byte{})).
+					"",
+					map[string]interface{}{"accountIds": []string{"uuid-sample-1", "uuid-sample-2"}}).
 					Return(&http.Request{}, errors.New("client: no http request created"))
 
 				fields.c = client
@@ -441,10 +414,9 @@ func Test_internalCustomerImpl_Add(t *testing.T) {
 				testCase.on(&testCase.fields)
 			}
 
-			smService, err := NewCustomerService(testCase.fields.c, "latest")
-			assert.NoError(t, err)
+			customerService := NewCustomerService(testCase.fields.c, "latest")
 
-			gotResponse, err := smService.Add(testCase.args.ctx, testCase.args.serviceDeskID, testCase.args.accountIDs)
+			gotResponse, err := customerService.Add(testCase.args.ctx, testCase.args.serviceDeskID, testCase.args.accountIDs)
 
 			if testCase.wantErr {
 
@@ -465,12 +437,8 @@ func Test_internalCustomerImpl_Add(t *testing.T) {
 
 func Test_internalCustomerImpl_Remove(t *testing.T) {
 
-	payloadMocked := &struct {
-		AccountIds []string "json:\"accountIds\""
-	}{AccountIds: []string{"uuid-sample-1", "uuid-sample-2"}}
-
 	type fields struct {
-		c service.Client
+		c service.Connector
 	}
 
 	type args struct {
@@ -496,17 +464,14 @@ func Test_internalCustomerImpl_Remove(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
-
-				client.On("TransformStructToReader",
-					payloadMocked).
-					Return(bytes.NewReader([]byte{}), nil)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodDelete,
 					"rest/servicedeskapi/servicedesk/10001/customer",
-					bytes.NewReader([]byte{})).
+					"",
+					map[string]interface{}{"accountIds": []string{"uuid-sample-1", "uuid-sample-2"}}).
 					Return(&http.Request{}, nil)
 
 				client.On("Call",
@@ -527,17 +492,14 @@ func Test_internalCustomerImpl_Remove(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
-
-				client.On("TransformStructToReader",
-					payloadMocked).
-					Return(bytes.NewReader([]byte{}), nil)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodDelete,
 					"rest/servicedeskapi/servicedesk/10001/customer",
-					bytes.NewReader([]byte{})).
+					"",
+					map[string]interface{}{"accountIds": []string{"uuid-sample-1", "uuid-sample-2"}}).
 					Return(&http.Request{}, nil)
 
 				client.On("Call",
@@ -560,17 +522,14 @@ func Test_internalCustomerImpl_Remove(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
-
-				client.On("TransformStructToReader",
-					payloadMocked).
-					Return(bytes.NewReader([]byte{}), nil)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodDelete,
 					"rest/servicedeskapi/servicedesk/10001/customer",
-					bytes.NewReader([]byte{})).
+					"",
+					map[string]interface{}{"accountIds": []string{"uuid-sample-1", "uuid-sample-2"}}).
 					Return(&http.Request{}, errors.New("client: no http request created"))
 
 				fields.c = client
@@ -606,10 +565,9 @@ func Test_internalCustomerImpl_Remove(t *testing.T) {
 				testCase.on(&testCase.fields)
 			}
 
-			smService, err := NewCustomerService(testCase.fields.c, "latest")
-			assert.NoError(t, err)
+			customerService := NewCustomerService(testCase.fields.c, "latest")
 
-			gotResponse, err := smService.Remove(testCase.args.ctx, testCase.args.serviceDeskID, testCase.args.accountIDs)
+			gotResponse, err := customerService.Remove(testCase.args.ctx, testCase.args.serviceDeskID, testCase.args.accountIDs)
 
 			if testCase.wantErr {
 

--- a/jira/sm/internal/feedback_impl_test.go
+++ b/jira/sm/internal/feedback_impl_test.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	model "github.com/ctreminiom/go-atlassian/pkg/infra/models"
@@ -15,7 +14,7 @@ import (
 func Test_internalServiceRequestFeedbackImpl_Get(t *testing.T) {
 
 	type fields struct {
-		c service.Client
+		c service.Connector
 	}
 
 	type args struct {
@@ -39,12 +38,13 @@ func Test_internalServiceRequestFeedbackImpl_Get(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodGet,
 					"rest/servicedeskapi/request/DESK-1/feedback",
+					"",
 					nil).
 					Return(&http.Request{}, nil)
 
@@ -65,12 +65,13 @@ func Test_internalServiceRequestFeedbackImpl_Get(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodGet,
 					"rest/servicedeskapi/request/DESK-1/feedback",
+					"",
 					nil).
 					Return(&http.Request{}, nil)
 
@@ -93,12 +94,13 @@ func Test_internalServiceRequestFeedbackImpl_Get(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodGet,
 					"rest/servicedeskapi/request/DESK-1/feedback",
+					"",
 					nil).
 					Return(&http.Request{}, errors.New("client: no http request created"))
 
@@ -125,10 +127,9 @@ func Test_internalServiceRequestFeedbackImpl_Get(t *testing.T) {
 				testCase.on(&testCase.fields)
 			}
 
-			smService, err := NewFeedbackService(testCase.fields.c, "latest")
-			assert.NoError(t, err)
+			feedbackService := NewFeedbackService(testCase.fields.c, "latest")
 
-			gotResult, gotResponse, err := smService.Get(testCase.args.ctx, testCase.args.requestIDOrKey)
+			gotResult, gotResponse, err := feedbackService.Get(testCase.args.ctx, testCase.args.requestIDOrKey)
 
 			if testCase.wantErr {
 
@@ -150,18 +151,8 @@ func Test_internalServiceRequestFeedbackImpl_Get(t *testing.T) {
 
 func Test_internalServiceRequestFeedbackImpl_Post(t *testing.T) {
 
-	payloadMocked := &struct {
-		Rating  int "json:\"rating,omitempty\""
-		Comment struct {
-			Body string "json:\"body,omitempty\""
-		} "json:\"comment,omitempty\""
-		Type string "json:\"type,omitempty\""
-	}{Rating: 5, Comment: struct {
-		Body string "json:\"body,omitempty\""
-	}{Body: "Excellent service"}, Type: "csat"}
-
 	type fields struct {
-		c service.Client
+		c service.Connector
 	}
 
 	type args struct {
@@ -189,17 +180,14 @@ func Test_internalServiceRequestFeedbackImpl_Post(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
-
-				client.On("TransformStructToReader",
-					payloadMocked).
-					Return(bytes.NewReader([]byte{}), nil)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodPost,
 					"rest/servicedeskapi/request/DESK-1/feedback",
-					bytes.NewReader([]byte{})).
+					"",
+					map[string]interface{}{"comment": map[string]interface{}{"body": "Excellent service"}, "rating": 5, "type": "csat"}).
 					Return(&http.Request{}, nil)
 
 				client.On("Call",
@@ -221,17 +209,14 @@ func Test_internalServiceRequestFeedbackImpl_Post(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
-
-				client.On("TransformStructToReader",
-					payloadMocked).
-					Return(bytes.NewReader([]byte{}), nil)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodPost,
 					"rest/servicedeskapi/request/DESK-1/feedback",
-					bytes.NewReader([]byte{})).
+					"",
+					map[string]interface{}{"comment": map[string]interface{}{"body": "Excellent service"}, "rating": 5, "type": "csat"}).
 					Return(&http.Request{}, nil)
 
 				client.On("Call",
@@ -255,17 +240,14 @@ func Test_internalServiceRequestFeedbackImpl_Post(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
-
-				client.On("TransformStructToReader",
-					payloadMocked).
-					Return(bytes.NewReader([]byte{}), nil)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodPost,
 					"rest/servicedeskapi/request/DESK-1/feedback",
-					bytes.NewReader([]byte{})).
+					"",
+					map[string]interface{}{"comment": map[string]interface{}{"body": "Excellent service"}, "rating": 5, "type": "csat"}).
 					Return(&http.Request{}, errors.New("client: no http request created"))
 
 				fields.c = client
@@ -291,10 +273,9 @@ func Test_internalServiceRequestFeedbackImpl_Post(t *testing.T) {
 				testCase.on(&testCase.fields)
 			}
 
-			smService, err := NewFeedbackService(testCase.fields.c, "latest")
-			assert.NoError(t, err)
+			feedbackService := NewFeedbackService(testCase.fields.c, "latest")
 
-			gotResult, gotResponse, err := smService.Post(testCase.args.ctx, testCase.args.requestIDOrKey, testCase.args.rating,
+			gotResult, gotResponse, err := feedbackService.Post(testCase.args.ctx, testCase.args.requestIDOrKey, testCase.args.rating,
 				testCase.args.comment)
 
 			if testCase.wantErr {
@@ -318,7 +299,7 @@ func Test_internalServiceRequestFeedbackImpl_Post(t *testing.T) {
 func Test_internalServiceRequestFeedbackImpl_Delete(t *testing.T) {
 
 	type fields struct {
-		c service.Client
+		c service.Connector
 	}
 
 	type args struct {
@@ -342,12 +323,13 @@ func Test_internalServiceRequestFeedbackImpl_Delete(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodDelete,
 					"rest/servicedeskapi/request/DESK-1/feedback",
+					"",
 					nil).
 					Return(&http.Request{}, nil)
 
@@ -368,12 +350,13 @@ func Test_internalServiceRequestFeedbackImpl_Delete(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodDelete,
 					"rest/servicedeskapi/request/DESK-1/feedback",
+					"",
 					nil).
 					Return(&http.Request{}, nil)
 
@@ -396,12 +379,13 @@ func Test_internalServiceRequestFeedbackImpl_Delete(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodDelete,
 					"rest/servicedeskapi/request/DESK-1/feedback",
+					"",
 					nil).
 					Return(&http.Request{}, errors.New("client: no http request created"))
 
@@ -428,10 +412,9 @@ func Test_internalServiceRequestFeedbackImpl_Delete(t *testing.T) {
 				testCase.on(&testCase.fields)
 			}
 
-			smService, err := NewFeedbackService(testCase.fields.c, "latest")
-			assert.NoError(t, err)
+			feedbackService := NewFeedbackService(testCase.fields.c, "latest")
 
-			gotResponse, err := smService.Delete(testCase.args.ctx, testCase.args.requestIDOrKey)
+			gotResponse, err := feedbackService.Delete(testCase.args.ctx, testCase.args.requestIDOrKey)
 
 			if testCase.wantErr {
 

--- a/jira/sm/internal/info_impl.go
+++ b/jira/sm/internal/info_impl.go
@@ -8,15 +8,11 @@ import (
 	"net/http"
 )
 
-func NewInfoService(client service.Client, version string) (*InfoService, error) {
-
-	if version == "" {
-		return nil, model.ErrNoVersionProvided
-	}
+func NewInfoService(client service.Connector, version string) *InfoService {
 
 	return &InfoService{
 		internalClient: &internalInfoImpl{c: client, version: version},
-	}, nil
+	}
 }
 
 type InfoService struct {
@@ -33,7 +29,7 @@ func (i *InfoService) Get(ctx context.Context) (*model.InfoScheme, *model.Respon
 }
 
 type internalInfoImpl struct {
-	c       service.Client
+	c       service.Connector
 	version string
 }
 
@@ -41,16 +37,16 @@ func (i *internalInfoImpl) Get(ctx context.Context) (*model.InfoScheme, *model.R
 
 	endpoint := "rest/servicedeskapi/info"
 
-	request, err := i.c.NewRequest(ctx, http.MethodGet, endpoint, nil)
+	req, err := i.c.NewRequest(ctx, http.MethodGet, endpoint, "", nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	info := new(model.InfoScheme)
-	response, err := i.c.Call(request, info)
+	res, err := i.c.Call(req, info)
 	if err != nil {
-		return nil, response, err
+		return nil, res, err
 	}
 
-	return info, response, nil
+	return info, res, nil
 }

--- a/jira/sm/internal/info_impl_test.go
+++ b/jira/sm/internal/info_impl_test.go
@@ -14,7 +14,7 @@ import (
 func Test_internalInfoImpl_Get(t *testing.T) {
 
 	type fields struct {
-		c service.Client
+		c service.Connector
 	}
 
 	type args struct {
@@ -36,12 +36,13 @@ func Test_internalInfoImpl_Get(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodGet,
 					"rest/servicedeskapi/info",
+					"",
 					nil).
 					Return(&http.Request{}, nil)
 
@@ -61,12 +62,13 @@ func Test_internalInfoImpl_Get(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodGet,
 					"rest/servicedeskapi/info",
+					"",
 					nil).
 					Return(&http.Request{}, nil)
 
@@ -88,12 +90,13 @@ func Test_internalInfoImpl_Get(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodGet,
 					"rest/servicedeskapi/info",
+					"",
 					nil).
 					Return(&http.Request{}, errors.New("client: no http request created"))
 
@@ -111,10 +114,9 @@ func Test_internalInfoImpl_Get(t *testing.T) {
 				testCase.on(&testCase.fields)
 			}
 
-			smService, err := NewInfoService(testCase.fields.c, "latest")
-			assert.NoError(t, err)
+			infoService := NewInfoService(testCase.fields.c, "latest")
 
-			gotResult, gotResponse, err := smService.Get(testCase.args.ctx)
+			gotResult, gotResponse, err := infoService.Get(testCase.args.ctx)
 
 			if testCase.wantErr {
 

--- a/jira/sm/internal/knowledgebase_impl.go
+++ b/jira/sm/internal/knowledgebase_impl.go
@@ -11,15 +11,11 @@ import (
 	"strconv"
 )
 
-func NewKnowledgebaseService(client service.Client, version string) (*KnowledgebaseService, error) {
-
-	if version == "" {
-		return nil, model.ErrNoVersionProvided
-	}
+func NewKnowledgebaseService(client service.Connector, version string) *KnowledgebaseService {
 
 	return &KnowledgebaseService{
 		internalClient: &internalKnowledgebaseImpl{c: client, version: version},
-	}, nil
+	}
 }
 
 type KnowledgebaseService struct {
@@ -45,7 +41,7 @@ func (k *KnowledgebaseService) Gets(ctx context.Context, serviceDeskID int, quer
 }
 
 type internalKnowledgebaseImpl struct {
-	c       service.Client
+	c       service.Connector
 	version string
 }
 
@@ -63,18 +59,18 @@ func (i *internalKnowledgebaseImpl) Search(ctx context.Context, query string, hi
 
 	endpoint := fmt.Sprintf("rest/servicedeskapi/knowledgebase/article?%v", params.Encode())
 
-	request, err := i.c.NewRequest(ctx, http.MethodGet, endpoint, nil)
+	req, err := i.c.NewRequest(ctx, http.MethodGet, endpoint, "", nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	page := new(model.ArticlePageScheme)
-	response, err := i.c.Call(request, page)
+	res, err := i.c.Call(req, page)
 	if err != nil {
-		return nil, response, err
+		return nil, res, err
 	}
 
-	return page, response, nil
+	return page, res, nil
 }
 
 func (i *internalKnowledgebaseImpl) Gets(ctx context.Context, serviceDeskID int, query string, highlight bool, start, limit int) (*model.ArticlePageScheme, *model.ResponseScheme, error) {
@@ -95,16 +91,16 @@ func (i *internalKnowledgebaseImpl) Gets(ctx context.Context, serviceDeskID int,
 
 	endpoint := fmt.Sprintf("rest/servicedeskapi/servicedesk/%v/knowledgebase/article?%v", serviceDeskID, params.Encode())
 
-	request, err := i.c.NewRequest(ctx, http.MethodGet, endpoint, nil)
+	req, err := i.c.NewRequest(ctx, http.MethodGet, endpoint, "", nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	page := new(model.ArticlePageScheme)
-	response, err := i.c.Call(request, page)
+	res, err := i.c.Call(req, page)
 	if err != nil {
-		return nil, response, err
+		return nil, res, err
 	}
 
-	return page, response, nil
+	return page, res, nil
 }

--- a/jira/sm/internal/knowledgebase_impl_test.go
+++ b/jira/sm/internal/knowledgebase_impl_test.go
@@ -14,7 +14,7 @@ import (
 func Test_internalKnowledgebaseImpl_Search(t *testing.T) {
 
 	type fields struct {
-		c service.Client
+		c service.Connector
 	}
 
 	type args struct {
@@ -43,12 +43,13 @@ func Test_internalKnowledgebaseImpl_Search(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodGet,
 					"rest/servicedeskapi/knowledgebase/article?highlight=true&limit=50&query=how+to+login+to+Jira%3F&start=50",
+					"",
 					nil).
 					Return(&http.Request{}, nil)
 
@@ -72,12 +73,13 @@ func Test_internalKnowledgebaseImpl_Search(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodGet,
 					"rest/servicedeskapi/knowledgebase/article?highlight=true&limit=50&query=how+to+login+to+Jira%3F&start=50",
+					"",
 					nil).
 					Return(&http.Request{}, nil)
 
@@ -103,12 +105,13 @@ func Test_internalKnowledgebaseImpl_Search(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodGet,
 					"rest/servicedeskapi/knowledgebase/article?highlight=true&limit=50&query=how+to+login+to+Jira%3F&start=50",
+					"",
 					nil).
 					Return(&http.Request{}, errors.New("client: no http request created"))
 
@@ -135,11 +138,13 @@ func Test_internalKnowledgebaseImpl_Search(t *testing.T) {
 				testCase.on(&testCase.fields)
 			}
 
-			smService, err := NewKnowledgebaseService(testCase.fields.c, "latest")
-			assert.NoError(t, err)
+			baseService := NewKnowledgebaseService(testCase.fields.c, "latest")
 
-			gotResult, gotResponse, err := smService.Search(testCase.args.ctx, testCase.args.query, testCase.args.highlight,
-				testCase.args.start, testCase.args.limit)
+			gotResult, gotResponse, err := baseService.Search(
+				testCase.args.ctx, testCase.args.query,
+				testCase.args.highlight, testCase.args.start,
+				testCase.args.limit,
+			)
 
 			if testCase.wantErr {
 
@@ -162,7 +167,7 @@ func Test_internalKnowledgebaseImpl_Search(t *testing.T) {
 func Test_internalKnowledgebaseImpl_Gets(t *testing.T) {
 
 	type fields struct {
-		c service.Client
+		c service.Connector
 	}
 
 	type args struct {
@@ -193,12 +198,13 @@ func Test_internalKnowledgebaseImpl_Gets(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodGet,
 					"rest/servicedeskapi/servicedesk/10001/knowledgebase/article?highlight=true&limit=50&query=how+to+login+to+Jira%3F&start=50",
+					"",
 					nil).
 					Return(&http.Request{}, nil)
 
@@ -223,12 +229,13 @@ func Test_internalKnowledgebaseImpl_Gets(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodGet,
 					"rest/servicedeskapi/servicedesk/10001/knowledgebase/article?highlight=true&limit=50&query=how+to+login+to+Jira%3F&start=50",
+					"",
 					nil).
 					Return(&http.Request{}, nil)
 
@@ -255,12 +262,13 @@ func Test_internalKnowledgebaseImpl_Gets(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodGet,
 					"rest/servicedeskapi/servicedesk/10001/knowledgebase/article?highlight=true&limit=50&query=how+to+login+to+Jira%3F&start=50",
+					"",
 					nil).
 					Return(&http.Request{}, errors.New("client: no http request created"))
 
@@ -297,11 +305,13 @@ func Test_internalKnowledgebaseImpl_Gets(t *testing.T) {
 				testCase.on(&testCase.fields)
 			}
 
-			smService, err := NewKnowledgebaseService(testCase.fields.c, "latest")
-			assert.NoError(t, err)
+			baseService := NewKnowledgebaseService(testCase.fields.c, "latest")
 
-			gotResult, gotResponse, err := smService.Gets(testCase.args.ctx, testCase.args.serviceDeskID, testCase.args.query, testCase.args.highlight,
-				testCase.args.start, testCase.args.limit)
+			gotResult, gotResponse, err := baseService.Gets(
+				testCase.args.ctx, testCase.args.serviceDeskID,
+				testCase.args.query, testCase.args.highlight,
+				testCase.args.start, testCase.args.limit,
+			)
 
 			if testCase.wantErr {
 

--- a/jira/sm/internal/organization_impl_test.go
+++ b/jira/sm/internal/organization_impl_test.go
@@ -1,0 +1,1342 @@
+package internal
+
+import (
+	"context"
+	"errors"
+	model "github.com/ctreminiom/go-atlassian/pkg/infra/models"
+	"github.com/ctreminiom/go-atlassian/service"
+	"github.com/ctreminiom/go-atlassian/service/mocks"
+	"github.com/stretchr/testify/assert"
+	"net/http"
+	"testing"
+)
+
+func Test_internalOrganizationImpl_Gets(t *testing.T) {
+
+	type fields struct {
+		c service.Connector
+	}
+
+	type args struct {
+		ctx          context.Context
+		accountID    string
+		start, limit int
+	}
+
+	testCases := []struct {
+		name    string
+		fields  fields
+		args    args
+		on      func(*fields)
+		wantErr bool
+		Err     error
+	}{
+		{
+			name: "when the parameters are correct",
+			args: args{
+				ctx:       context.Background(),
+				accountID: "account-id-sample",
+				start:     100,
+				limit:     50,
+			},
+			on: func(fields *fields) {
+
+				client := mocks.NewConnector(t)
+
+				client.On("NewRequest",
+					context.Background(),
+					http.MethodGet,
+					"rest/servicedeskapi/organization?accountId=account-id-sample&limit=50&start=100",
+					"",
+					nil).
+					Return(&http.Request{}, nil)
+
+				client.On("Call",
+					&http.Request{},
+					&model.OrganizationPageScheme{}).
+					Return(&model.ResponseScheme{}, nil)
+
+				fields.c = client
+			},
+		},
+
+		{
+			name: "when the http call cannot be executed",
+			args: args{
+				ctx:       context.Background(),
+				accountID: "account-id-sample",
+				start:     100,
+				limit:     50,
+			},
+			on: func(fields *fields) {
+
+				client := mocks.NewConnector(t)
+
+				client.On("NewRequest",
+					context.Background(),
+					http.MethodGet,
+					"rest/servicedeskapi/organization?accountId=account-id-sample&limit=50&start=100",
+					"",
+					nil).
+					Return(&http.Request{}, nil)
+
+				client.On("Call",
+					&http.Request{},
+					&model.OrganizationPageScheme{}).
+					Return(&model.ResponseScheme{}, errors.New("client: no http response found"))
+
+				fields.c = client
+			},
+			Err:     errors.New("client: no http response found"),
+			wantErr: true,
+		},
+
+		{
+			name: "when the request cannot be created",
+			args: args{
+				ctx:       context.Background(),
+				accountID: "account-id-sample",
+				start:     100,
+				limit:     50,
+			},
+			on: func(fields *fields) {
+
+				client := mocks.NewConnector(t)
+
+				client.On("NewRequest",
+					context.Background(),
+					http.MethodGet,
+					"rest/servicedeskapi/organization?accountId=account-id-sample&limit=50&start=100",
+					"",
+					nil).
+					Return(&http.Request{}, errors.New("client: no http request created"))
+
+				fields.c = client
+			},
+			Err:     errors.New("client: no http request created"),
+			wantErr: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+
+			if testCase.on != nil {
+				testCase.on(&testCase.fields)
+			}
+
+			organizationService := NewOrganizationService(testCase.fields.c, "latest")
+
+			gotResult, gotResponse, err := organizationService.Gets(testCase.args.ctx, testCase.args.accountID,
+				testCase.args.start, testCase.args.limit)
+
+			if testCase.wantErr {
+
+				if err != nil {
+					t.Logf("error returned: %v", err.Error())
+				}
+
+				assert.EqualError(t, err, testCase.Err.Error())
+
+			} else {
+
+				assert.NoError(t, err)
+				assert.NotEqual(t, gotResponse, nil)
+				assert.NotEqual(t, gotResult, nil)
+			}
+		})
+	}
+}
+
+func Test_internalOrganizationImpl_Get(t *testing.T) {
+
+	type fields struct {
+		c service.Connector
+	}
+
+	type args struct {
+		ctx            context.Context
+		organizationID int
+	}
+
+	testCases := []struct {
+		name    string
+		fields  fields
+		args    args
+		on      func(*fields)
+		wantErr bool
+		Err     error
+	}{
+		{
+			name: "when the parameters are correct",
+			args: args{
+				ctx:            context.Background(),
+				organizationID: 100001,
+			},
+			on: func(fields *fields) {
+
+				client := mocks.NewConnector(t)
+
+				client.On("NewRequest",
+					context.Background(),
+					http.MethodGet,
+					"rest/servicedeskapi/organization/100001",
+					"",
+					nil).
+					Return(&http.Request{}, nil)
+
+				client.On("Call",
+					&http.Request{},
+					&model.OrganizationScheme{}).
+					Return(&model.ResponseScheme{}, nil)
+
+				fields.c = client
+			},
+		},
+
+		{
+			name: "when the http call cannot be executed",
+			args: args{
+				ctx:            context.Background(),
+				organizationID: 100001,
+			},
+			on: func(fields *fields) {
+
+				client := mocks.NewConnector(t)
+
+				client.On("NewRequest",
+					context.Background(),
+					http.MethodGet,
+					"rest/servicedeskapi/organization/100001",
+					"",
+					nil).
+					Return(&http.Request{}, nil)
+
+				client.On("Call",
+					&http.Request{},
+					&model.OrganizationScheme{}).
+					Return(&model.ResponseScheme{}, errors.New("client: no http response found"))
+
+				fields.c = client
+			},
+			Err:     errors.New("client: no http response found"),
+			wantErr: true,
+		},
+
+		{
+			name: "when the request cannot be created",
+			args: args{
+				ctx:            context.Background(),
+				organizationID: 100001,
+			},
+			on: func(fields *fields) {
+
+				client := mocks.NewConnector(t)
+
+				client.On("NewRequest",
+					context.Background(),
+					http.MethodGet,
+					"rest/servicedeskapi/organization/100001",
+					"",
+					nil).
+					Return(&http.Request{}, errors.New("client: no http request created"))
+
+				fields.c = client
+			},
+			Err:     errors.New("client: no http request created"),
+			wantErr: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+
+			if testCase.on != nil {
+				testCase.on(&testCase.fields)
+			}
+
+			organizationService := NewOrganizationService(testCase.fields.c, "latest")
+
+			gotResult, gotResponse, err := organizationService.Get(testCase.args.ctx, testCase.args.organizationID)
+
+			if testCase.wantErr {
+
+				if err != nil {
+					t.Logf("error returned: %v", err.Error())
+				}
+
+				assert.EqualError(t, err, testCase.Err.Error())
+
+			} else {
+
+				assert.NoError(t, err)
+				assert.NotEqual(t, gotResponse, nil)
+				assert.NotEqual(t, gotResult, nil)
+			}
+		})
+	}
+}
+
+func Test_internalOrganizationImpl_Delete(t *testing.T) {
+
+	type fields struct {
+		c service.Connector
+	}
+
+	type args struct {
+		ctx            context.Context
+		organizationID int
+	}
+
+	testCases := []struct {
+		name    string
+		fields  fields
+		args    args
+		on      func(*fields)
+		wantErr bool
+		Err     error
+	}{
+		{
+			name: "when the parameters are correct",
+			args: args{
+				ctx:            context.Background(),
+				organizationID: 100001,
+			},
+			on: func(fields *fields) {
+
+				client := mocks.NewConnector(t)
+
+				client.On("NewRequest",
+					context.Background(),
+					http.MethodDelete,
+					"rest/servicedeskapi/organization/100001",
+					"",
+					nil).
+					Return(&http.Request{}, nil)
+
+				client.On("Call",
+					&http.Request{},
+					nil).
+					Return(&model.ResponseScheme{}, nil)
+
+				fields.c = client
+			},
+		},
+
+		{
+			name: "when the http call cannot be executed",
+			args: args{
+				ctx:            context.Background(),
+				organizationID: 100001,
+			},
+			on: func(fields *fields) {
+
+				client := mocks.NewConnector(t)
+
+				client.On("NewRequest",
+					context.Background(),
+					http.MethodDelete,
+					"rest/servicedeskapi/organization/100001",
+					"",
+					nil).
+					Return(&http.Request{}, nil)
+
+				client.On("Call",
+					&http.Request{},
+					nil).
+					Return(&model.ResponseScheme{}, errors.New("client: no http response found"))
+
+				fields.c = client
+			},
+			Err:     errors.New("client: no http response found"),
+			wantErr: true,
+		},
+
+		{
+			name: "when the request cannot be created",
+			args: args{
+				ctx:            context.Background(),
+				organizationID: 100001,
+			},
+			on: func(fields *fields) {
+
+				client := mocks.NewConnector(t)
+
+				client.On("NewRequest",
+					context.Background(),
+					http.MethodDelete,
+					"rest/servicedeskapi/organization/100001",
+					"",
+					nil).
+					Return(&http.Request{}, errors.New("client: no http request created"))
+
+				fields.c = client
+			},
+			Err:     errors.New("client: no http request created"),
+			wantErr: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+
+			if testCase.on != nil {
+				testCase.on(&testCase.fields)
+			}
+
+			organizationService := NewOrganizationService(testCase.fields.c, "latest")
+
+			gotResponse, err := organizationService.Delete(testCase.args.ctx, testCase.args.organizationID)
+
+			if testCase.wantErr {
+
+				if err != nil {
+					t.Logf("error returned: %v", err.Error())
+				}
+
+				assert.EqualError(t, err, testCase.Err.Error())
+
+			} else {
+
+				assert.NoError(t, err)
+				assert.NotEqual(t, gotResponse, nil)
+			}
+		})
+	}
+}
+
+func Test_internalOrganizationImpl_Create(t *testing.T) {
+
+	type fields struct {
+		c service.Connector
+	}
+
+	type args struct {
+		ctx  context.Context
+		name string
+	}
+
+	testCases := []struct {
+		name    string
+		fields  fields
+		args    args
+		on      func(*fields)
+		wantErr bool
+		Err     error
+	}{
+		{
+			name: "when the parameters are correct",
+			args: args{
+				ctx:  context.Background(),
+				name: "Client A - Organization Users",
+			},
+			on: func(fields *fields) {
+
+				client := mocks.NewConnector(t)
+
+				client.On("NewRequest",
+					context.Background(),
+					http.MethodPost,
+					"rest/servicedeskapi/organization",
+					"",
+					map[string]interface{}{"name": "Client A - Organization Users"}).
+					Return(&http.Request{}, nil)
+
+				client.On("Call",
+					&http.Request{},
+					&model.OrganizationScheme{}).
+					Return(&model.ResponseScheme{}, nil)
+
+				fields.c = client
+			},
+		},
+
+		{
+			name: "when the http call cannot be executed",
+			args: args{
+				ctx:  context.Background(),
+				name: "Client A - Organization Users",
+			},
+			on: func(fields *fields) {
+
+				client := mocks.NewConnector(t)
+
+				client.On("NewRequest",
+					context.Background(),
+					http.MethodPost,
+					"rest/servicedeskapi/organization",
+					"",
+					map[string]interface{}{"name": "Client A - Organization Users"}).
+					Return(&http.Request{}, nil)
+
+				client.On("Call",
+					&http.Request{},
+					&model.OrganizationScheme{}).
+					Return(&model.ResponseScheme{}, errors.New("client: no http response found"))
+
+				fields.c = client
+			},
+			Err:     errors.New("client: no http response found"),
+			wantErr: true,
+		},
+
+		{
+			name: "when the request cannot be created",
+			args: args{
+				ctx:  context.Background(),
+				name: "Client A - Organization Users",
+			},
+			on: func(fields *fields) {
+
+				client := mocks.NewConnector(t)
+
+				client.On("NewRequest",
+					context.Background(),
+					http.MethodPost,
+					"rest/servicedeskapi/organization",
+					"",
+					map[string]interface{}{"name": "Client A - Organization Users"}).
+					Return(&http.Request{}, errors.New("client: no http request created"))
+
+				fields.c = client
+			},
+			Err:     errors.New("client: no http request created"),
+			wantErr: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+
+			if testCase.on != nil {
+				testCase.on(&testCase.fields)
+			}
+
+			organizationService := NewOrganizationService(testCase.fields.c, "latest")
+
+			gotResult, gotResponse, err := organizationService.Create(testCase.args.ctx, testCase.args.name)
+
+			if testCase.wantErr {
+
+				if err != nil {
+					t.Logf("error returned: %v", err.Error())
+				}
+
+				assert.EqualError(t, err, testCase.Err.Error())
+
+			} else {
+
+				assert.NoError(t, err)
+				assert.NotEqual(t, gotResponse, nil)
+				assert.NotEqual(t, gotResult, nil)
+			}
+		})
+	}
+}
+
+func Test_internalOrganizationImpl_Users(t *testing.T) {
+
+	type fields struct {
+		c service.Connector
+	}
+
+	type args struct {
+		ctx                          context.Context
+		organizationID, start, limit int
+	}
+
+	testCases := []struct {
+		name    string
+		fields  fields
+		args    args
+		on      func(*fields)
+		wantErr bool
+		Err     error
+	}{
+		{
+			name: "when the parameters are correct",
+			args: args{
+				ctx:            context.Background(),
+				organizationID: 10001,
+				start:          100,
+				limit:          50,
+			},
+			on: func(fields *fields) {
+
+				client := mocks.NewConnector(t)
+
+				client.On("NewRequest",
+					context.Background(),
+					http.MethodGet,
+					"rest/servicedeskapi/organization/10001/user?limit=50&start=100",
+					"",
+					nil).
+					Return(&http.Request{}, nil)
+
+				client.On("Call",
+					&http.Request{},
+					&model.OrganizationUsersPageScheme{}).
+					Return(&model.ResponseScheme{}, nil)
+
+				fields.c = client
+			},
+		},
+
+		{
+			name: "when the http call cannot be executed",
+			args: args{
+				ctx:            context.Background(),
+				organizationID: 10001,
+				start:          100,
+				limit:          50,
+			},
+			on: func(fields *fields) {
+
+				client := mocks.NewConnector(t)
+
+				client.On("NewRequest",
+					context.Background(),
+					http.MethodGet,
+					"rest/servicedeskapi/organization/10001/user?limit=50&start=100",
+					"",
+					nil).
+					Return(&http.Request{}, nil)
+
+				client.On("Call",
+					&http.Request{},
+					&model.OrganizationUsersPageScheme{}).
+					Return(&model.ResponseScheme{}, errors.New("client: no http response found"))
+
+				fields.c = client
+			},
+			Err:     errors.New("client: no http response found"),
+			wantErr: true,
+		},
+
+		{
+			name: "when the request cannot be created",
+			args: args{
+				ctx:            context.Background(),
+				organizationID: 10001,
+				start:          100,
+				limit:          50,
+			},
+			on: func(fields *fields) {
+
+				client := mocks.NewConnector(t)
+
+				client.On("NewRequest",
+					context.Background(),
+					http.MethodGet,
+					"rest/servicedeskapi/organization/10001/user?limit=50&start=100",
+					"",
+					nil).
+					Return(&http.Request{}, errors.New("client: no http request created"))
+
+				fields.c = client
+			},
+			Err:     errors.New("client: no http request created"),
+			wantErr: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+
+			if testCase.on != nil {
+				testCase.on(&testCase.fields)
+			}
+
+			organizationService := NewOrganizationService(testCase.fields.c, "latest")
+
+			gotResult, gotResponse, err := organizationService.Users(testCase.args.ctx, testCase.args.organizationID,
+				testCase.args.start, testCase.args.limit)
+
+			if testCase.wantErr {
+
+				if err != nil {
+					t.Logf("error returned: %v", err.Error())
+				}
+
+				assert.EqualError(t, err, testCase.Err.Error())
+
+			} else {
+
+				assert.NoError(t, err)
+				assert.NotEqual(t, gotResponse, nil)
+				assert.NotEqual(t, gotResult, nil)
+			}
+		})
+	}
+}
+
+func Test_internalOrganizationImpl_Add(t *testing.T) {
+
+	type fields struct {
+		c service.Connector
+	}
+
+	type args struct {
+		ctx            context.Context
+		organizationID int
+		accountIDs     []string
+	}
+
+	testCases := []struct {
+		name    string
+		fields  fields
+		args    args
+		on      func(*fields)
+		wantErr bool
+		Err     error
+	}{
+		{
+			name: "when the parameters are correct",
+			args: args{
+				ctx:            context.Background(),
+				organizationID: 10001,
+				accountIDs:     []string{"account-id-sample", "account-id-sample-2"},
+			},
+			on: func(fields *fields) {
+
+				client := mocks.NewConnector(t)
+
+				client.On("NewRequest",
+					context.Background(),
+					http.MethodPost,
+					"rest/servicedeskapi/organization/10001/user",
+					"",
+					map[string]interface{}{"accountIds": []string{"account-id-sample", "account-id-sample-2"}}).
+					Return(&http.Request{}, nil)
+
+				client.On("Call",
+					&http.Request{},
+					nil).
+					Return(&model.ResponseScheme{}, nil)
+
+				fields.c = client
+			},
+		},
+
+		{
+			name: "when the http call cannot be executed",
+			args: args{
+				ctx:            context.Background(),
+				organizationID: 10001,
+				accountIDs:     []string{"account-id-sample", "account-id-sample-2"},
+			},
+			on: func(fields *fields) {
+
+				client := mocks.NewConnector(t)
+
+				client.On("NewRequest",
+					context.Background(),
+					http.MethodPost,
+					"rest/servicedeskapi/organization/10001/user",
+					"",
+					map[string]interface{}{"accountIds": []string{"account-id-sample", "account-id-sample-2"}}).
+					Return(&http.Request{}, nil)
+
+				client.On("Call",
+					&http.Request{},
+					nil).
+					Return(&model.ResponseScheme{}, errors.New("client: no http response found"))
+
+				fields.c = client
+			},
+			Err:     errors.New("client: no http response found"),
+			wantErr: true,
+		},
+
+		{
+			name: "when the request cannot be created",
+			args: args{
+				ctx:            context.Background(),
+				organizationID: 10001,
+				accountIDs:     []string{"account-id-sample", "account-id-sample-2"},
+			},
+			on: func(fields *fields) {
+
+				client := mocks.NewConnector(t)
+
+				client.On("NewRequest",
+					context.Background(),
+					http.MethodPost,
+					"rest/servicedeskapi/organization/10001/user",
+					"",
+					map[string]interface{}{"accountIds": []string{"account-id-sample", "account-id-sample-2"}}).
+					Return(&http.Request{}, errors.New("client: no http request created"))
+
+				fields.c = client
+			},
+			Err:     errors.New("client: no http request created"),
+			wantErr: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+
+			if testCase.on != nil {
+				testCase.on(&testCase.fields)
+			}
+
+			organizationService := NewOrganizationService(testCase.fields.c, "latest")
+
+			gotResponse, err := organizationService.Add(testCase.args.ctx, testCase.args.organizationID,
+				testCase.args.accountIDs)
+
+			if testCase.wantErr {
+
+				if err != nil {
+					t.Logf("error returned: %v", err.Error())
+				}
+
+				assert.EqualError(t, err, testCase.Err.Error())
+
+			} else {
+
+				assert.NoError(t, err)
+				assert.NotEqual(t, gotResponse, nil)
+			}
+		})
+	}
+}
+
+func Test_internalOrganizationImpl_Remove(t *testing.T) {
+
+	type fields struct {
+		c service.Connector
+	}
+
+	type args struct {
+		ctx            context.Context
+		organizationID int
+		accountIDs     []string
+	}
+
+	testCases := []struct {
+		name    string
+		fields  fields
+		args    args
+		on      func(*fields)
+		wantErr bool
+		Err     error
+	}{
+		{
+			name: "when the parameters are correct",
+			args: args{
+				ctx:            context.Background(),
+				organizationID: 10001,
+				accountIDs:     []string{"account-id-sample", "account-id-sample-2"},
+			},
+			on: func(fields *fields) {
+
+				client := mocks.NewConnector(t)
+
+				client.On("NewRequest",
+					context.Background(),
+					http.MethodDelete,
+					"rest/servicedeskapi/organization/10001/user",
+					"",
+					map[string]interface{}{"accountIds": []string{"account-id-sample", "account-id-sample-2"}}).
+					Return(&http.Request{}, nil)
+
+				client.On("Call",
+					&http.Request{},
+					nil).
+					Return(&model.ResponseScheme{}, nil)
+
+				fields.c = client
+			},
+		},
+
+		{
+			name: "when the http call cannot be executed",
+			args: args{
+				ctx:            context.Background(),
+				organizationID: 10001,
+				accountIDs:     []string{"account-id-sample", "account-id-sample-2"},
+			},
+			on: func(fields *fields) {
+
+				client := mocks.NewConnector(t)
+
+				client.On("NewRequest",
+					context.Background(),
+					http.MethodDelete,
+					"rest/servicedeskapi/organization/10001/user",
+					"",
+					map[string]interface{}{"accountIds": []string{"account-id-sample", "account-id-sample-2"}}).
+					Return(&http.Request{}, nil)
+
+				client.On("Call",
+					&http.Request{},
+					nil).
+					Return(&model.ResponseScheme{}, errors.New("client: no http response found"))
+
+				fields.c = client
+			},
+			Err:     errors.New("client: no http response found"),
+			wantErr: true,
+		},
+
+		{
+			name: "when the request cannot be created",
+			args: args{
+				ctx:            context.Background(),
+				organizationID: 10001,
+				accountIDs:     []string{"account-id-sample", "account-id-sample-2"},
+			},
+			on: func(fields *fields) {
+
+				client := mocks.NewConnector(t)
+
+				client.On("NewRequest",
+					context.Background(),
+					http.MethodDelete,
+					"rest/servicedeskapi/organization/10001/user",
+					"",
+					map[string]interface{}{"accountIds": []string{"account-id-sample", "account-id-sample-2"}}).
+					Return(&http.Request{}, errors.New("client: no http request created"))
+
+				fields.c = client
+			},
+			Err:     errors.New("client: no http request created"),
+			wantErr: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+
+			if testCase.on != nil {
+				testCase.on(&testCase.fields)
+			}
+
+			organizationService := NewOrganizationService(testCase.fields.c, "latest")
+
+			gotResponse, err := organizationService.Remove(testCase.args.ctx, testCase.args.organizationID,
+				testCase.args.accountIDs)
+
+			if testCase.wantErr {
+
+				if err != nil {
+					t.Logf("error returned: %v", err.Error())
+				}
+
+				assert.EqualError(t, err, testCase.Err.Error())
+
+			} else {
+
+				assert.NoError(t, err)
+				assert.NotEqual(t, gotResponse, nil)
+			}
+		})
+	}
+}
+
+func Test_internalOrganizationImpl_Project(t *testing.T) {
+
+	type fields struct {
+		c service.Connector
+	}
+
+	type args struct {
+		ctx                         context.Context
+		accountID                   string
+		serviceDeskID, start, limit int
+	}
+
+	testCases := []struct {
+		name    string
+		fields  fields
+		args    args
+		on      func(*fields)
+		wantErr bool
+		Err     error
+	}{
+		{
+			name: "when the parameters are correct",
+			args: args{
+				ctx:           context.Background(),
+				accountID:     "account-id-sample",
+				serviceDeskID: 1001,
+				start:         100,
+				limit:         50,
+			},
+			on: func(fields *fields) {
+
+				client := mocks.NewConnector(t)
+
+				client.On("NewRequest",
+					context.Background(),
+					http.MethodGet,
+					"rest/servicedeskapi/servicedesk/1001/organization?accountId=account-id-sample&limit=50&start=100",
+					"",
+					nil).
+					Return(&http.Request{}, nil)
+
+				client.On("Call",
+					&http.Request{},
+					&model.OrganizationPageScheme{}).
+					Return(&model.ResponseScheme{}, nil)
+
+				fields.c = client
+			},
+		},
+
+		{
+			name: "when the http call cannot be executed",
+			args: args{
+				ctx:           context.Background(),
+				accountID:     "account-id-sample",
+				serviceDeskID: 1001,
+				start:         100,
+				limit:         50,
+			},
+			on: func(fields *fields) {
+
+				client := mocks.NewConnector(t)
+
+				client.On("NewRequest",
+					context.Background(),
+					http.MethodGet,
+					"rest/servicedeskapi/servicedesk/1001/organization?accountId=account-id-sample&limit=50&start=100",
+					"",
+					nil).
+					Return(&http.Request{}, nil)
+
+				client.On("Call",
+					&http.Request{},
+					&model.OrganizationPageScheme{}).
+					Return(&model.ResponseScheme{}, errors.New("client: no http response found"))
+
+				fields.c = client
+			},
+			Err:     errors.New("client: no http response found"),
+			wantErr: true,
+		},
+
+		{
+			name: "when the request cannot be created",
+			args: args{
+				ctx:           context.Background(),
+				accountID:     "account-id-sample",
+				serviceDeskID: 1001,
+				start:         100,
+				limit:         50,
+			},
+			on: func(fields *fields) {
+
+				client := mocks.NewConnector(t)
+
+				client.On("NewRequest",
+					context.Background(),
+					http.MethodGet,
+					"rest/servicedeskapi/servicedesk/1001/organization?accountId=account-id-sample&limit=50&start=100",
+					"",
+					nil).
+					Return(&http.Request{}, errors.New("client: no http request created"))
+
+				fields.c = client
+			},
+			Err:     errors.New("client: no http request created"),
+			wantErr: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+
+			if testCase.on != nil {
+				testCase.on(&testCase.fields)
+			}
+
+			organizationService := NewOrganizationService(testCase.fields.c, "latest")
+
+			gotResult, gotResponse, err := organizationService.Project(testCase.args.ctx, testCase.args.accountID,
+				testCase.args.serviceDeskID,
+				testCase.args.start, testCase.args.limit)
+
+			if testCase.wantErr {
+
+				if err != nil {
+					t.Logf("error returned: %v", err.Error())
+				}
+
+				assert.EqualError(t, err, testCase.Err.Error())
+
+			} else {
+
+				assert.NoError(t, err)
+				assert.NotEqual(t, gotResponse, nil)
+				assert.NotEqual(t, gotResult, nil)
+			}
+		})
+	}
+}
+
+func Test_internalOrganizationImpl_Associate(t *testing.T) {
+
+	type fields struct {
+		c service.Connector
+	}
+
+	type args struct {
+		ctx                           context.Context
+		serviceDeskID, organizationID int
+	}
+
+	testCases := []struct {
+		name    string
+		fields  fields
+		args    args
+		on      func(*fields)
+		wantErr bool
+		Err     error
+	}{
+		{
+			name: "when the parameters are correct",
+			args: args{
+				ctx:            context.Background(),
+				organizationID: 10001,
+				serviceDeskID:  100022,
+			},
+			on: func(fields *fields) {
+
+				client := mocks.NewConnector(t)
+
+				client.On("NewRequest",
+					context.Background(),
+					http.MethodPost,
+					"rest/servicedeskapi/servicedesk/10001/organization",
+					"",
+					map[string]interface{}{"organizationId": 100022}).
+					Return(&http.Request{}, nil)
+
+				client.On("Call",
+					&http.Request{},
+					nil).
+					Return(&model.ResponseScheme{}, nil)
+
+				fields.c = client
+			},
+		},
+
+		{
+			name: "when the http call cannot be executed",
+			args: args{
+				ctx:            context.Background(),
+				organizationID: 10001,
+				serviceDeskID:  100022,
+			},
+			on: func(fields *fields) {
+
+				client := mocks.NewConnector(t)
+
+				client.On("NewRequest",
+					context.Background(),
+					http.MethodPost,
+					"rest/servicedeskapi/servicedesk/10001/organization",
+					"",
+					map[string]interface{}{"organizationId": 100022}).
+					Return(&http.Request{}, nil)
+
+				client.On("Call",
+					&http.Request{},
+					nil).
+					Return(&model.ResponseScheme{}, errors.New("client: no http response found"))
+
+				fields.c = client
+			},
+			Err:     errors.New("client: no http response found"),
+			wantErr: true,
+		},
+
+		{
+			name: "when the request cannot be created",
+			args: args{
+				ctx:            context.Background(),
+				organizationID: 10001,
+				serviceDeskID:  100022,
+			},
+			on: func(fields *fields) {
+
+				client := mocks.NewConnector(t)
+
+				client.On("NewRequest",
+					context.Background(),
+					http.MethodPost,
+					"rest/servicedeskapi/servicedesk/10001/organization",
+					"",
+					map[string]interface{}{"organizationId": 100022}).
+					Return(&http.Request{}, errors.New("client: no http request created"))
+
+				fields.c = client
+			},
+			Err:     errors.New("client: no http request created"),
+			wantErr: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+
+			if testCase.on != nil {
+				testCase.on(&testCase.fields)
+			}
+
+			organizationService := NewOrganizationService(testCase.fields.c, "latest")
+
+			gotResponse, err := organizationService.Associate(testCase.args.ctx, testCase.args.organizationID,
+				testCase.args.serviceDeskID)
+
+			if testCase.wantErr {
+
+				if err != nil {
+					t.Logf("error returned: %v", err.Error())
+				}
+
+				assert.EqualError(t, err, testCase.Err.Error())
+
+			} else {
+
+				assert.NoError(t, err)
+				assert.NotEqual(t, gotResponse, nil)
+			}
+		})
+	}
+}
+
+func Test_internalOrganizationImpl_Detach(t *testing.T) {
+
+	type fields struct {
+		c service.Connector
+	}
+
+	type args struct {
+		ctx                           context.Context
+		serviceDeskID, organizationID int
+	}
+
+	testCases := []struct {
+		name    string
+		fields  fields
+		args    args
+		on      func(*fields)
+		wantErr bool
+		Err     error
+	}{
+		{
+			name: "when the parameters are correct",
+			args: args{
+				ctx:            context.Background(),
+				organizationID: 10001,
+				serviceDeskID:  100022,
+			},
+			on: func(fields *fields) {
+
+				client := mocks.NewConnector(t)
+
+				client.On("NewRequest",
+					context.Background(),
+					http.MethodDelete,
+					"rest/servicedeskapi/servicedesk/10001/organization",
+					"",
+					map[string]interface{}{"organizationId": 100022}).
+					Return(&http.Request{}, nil)
+
+				client.On("Call",
+					&http.Request{},
+					nil).
+					Return(&model.ResponseScheme{}, nil)
+
+				fields.c = client
+			},
+		},
+
+		{
+			name: "when the http call cannot be executed",
+			args: args{
+				ctx:            context.Background(),
+				organizationID: 10001,
+				serviceDeskID:  100022,
+			},
+			on: func(fields *fields) {
+
+				client := mocks.NewConnector(t)
+
+				client.On("NewRequest",
+					context.Background(),
+					http.MethodDelete,
+					"rest/servicedeskapi/servicedesk/10001/organization",
+					"",
+					map[string]interface{}{"organizationId": 100022}).
+					Return(&http.Request{}, nil)
+
+				client.On("Call",
+					&http.Request{},
+					nil).
+					Return(&model.ResponseScheme{}, errors.New("client: no http response found"))
+
+				fields.c = client
+			},
+			Err:     errors.New("client: no http response found"),
+			wantErr: true,
+		},
+
+		{
+			name: "when the request cannot be created",
+			args: args{
+				ctx:            context.Background(),
+				organizationID: 10001,
+				serviceDeskID:  100022,
+			},
+			on: func(fields *fields) {
+
+				client := mocks.NewConnector(t)
+
+				client.On("NewRequest",
+					context.Background(),
+					http.MethodDelete,
+					"rest/servicedeskapi/servicedesk/10001/organization",
+					"",
+					map[string]interface{}{"organizationId": 100022}).
+					Return(&http.Request{}, errors.New("client: no http request created"))
+
+				fields.c = client
+			},
+			Err:     errors.New("client: no http request created"),
+			wantErr: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+
+			if testCase.on != nil {
+				testCase.on(&testCase.fields)
+			}
+
+			organizationService := NewOrganizationService(testCase.fields.c, "latest")
+
+			gotResponse, err := organizationService.Detach(testCase.args.ctx, testCase.args.organizationID,
+				testCase.args.serviceDeskID)
+
+			if testCase.wantErr {
+
+				if err != nil {
+					t.Logf("error returned: %v", err.Error())
+				}
+
+				assert.EqualError(t, err, testCase.Err.Error())
+
+			} else {
+
+				assert.NoError(t, err)
+				assert.NotEqual(t, gotResponse, nil)
+			}
+		})
+	}
+}

--- a/jira/sm/internal/participant_impl.go
+++ b/jira/sm/internal/participant_impl.go
@@ -11,15 +11,11 @@ import (
 	"strconv"
 )
 
-func NewParticipantService(client service.Client, version string) (*ParticipantService, error) {
-
-	if version == "" {
-		return nil, model.ErrNoVersionProvided
-	}
+func NewParticipantService(client service.Connector, version string) *ParticipantService {
 
 	return &ParticipantService{
 		internalClient: &internalServiceRequestParticipantImpl{c: client, version: version},
-	}, nil
+	}
 }
 
 type ParticipantService struct {
@@ -54,7 +50,7 @@ func (s *ParticipantService) Remove(ctx context.Context, issueKeyOrID string, ac
 }
 
 type internalServiceRequestParticipantImpl struct {
-	c       service.Client
+	c       service.Connector
 	version string
 }
 
@@ -70,18 +66,18 @@ func (i *internalServiceRequestParticipantImpl) Gets(ctx context.Context, issueK
 
 	endpoint := fmt.Sprintf("rest/servicedeskapi/request/%v/participant?%v", issueKeyOrID, params.Encode())
 
-	request, err := i.c.NewRequest(ctx, http.MethodGet, endpoint, nil)
+	req, err := i.c.NewRequest(ctx, http.MethodGet, endpoint, "", nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	page := new(model.RequestParticipantPageScheme)
-	response, err := i.c.Call(request, page)
+	res, err := i.c.Call(req, page)
 	if err != nil {
-		return nil, response, err
+		return nil, res, err
 	}
 
-	return page, response, nil
+	return page, res, nil
 }
 
 func (i *internalServiceRequestParticipantImpl) Add(ctx context.Context, issueKeyOrID string, accountIDs []string) (*model.RequestParticipantPageScheme, *model.ResponseScheme, error) {
@@ -94,31 +90,20 @@ func (i *internalServiceRequestParticipantImpl) Add(ctx context.Context, issueKe
 		return nil, nil, model.ErrNoAccountSliceError
 	}
 
-	payload := struct {
-		AccountIds []string `json:"accountIds"`
-	}{
-		AccountIds: accountIDs,
-	}
-
-	reader, err := i.c.TransformStructToReader(&payload)
-	if err != nil {
-		return nil, nil, err
-	}
-
 	endpoint := fmt.Sprintf("rest/servicedeskapi/request/%v/participant", issueKeyOrID)
 
-	request, err := i.c.NewRequest(ctx, http.MethodPost, endpoint, reader)
+	req, err := i.c.NewRequest(ctx, http.MethodPost, endpoint, "", map[string]interface{}{"accountIds": accountIDs})
 	if err != nil {
 		return nil, nil, err
 	}
 
 	page := new(model.RequestParticipantPageScheme)
-	response, err := i.c.Call(request, page)
+	res, err := i.c.Call(req, page)
 	if err != nil {
-		return nil, response, err
+		return nil, res, err
 	}
 
-	return page, response, nil
+	return page, res, nil
 }
 
 func (i *internalServiceRequestParticipantImpl) Remove(ctx context.Context, issueKeyOrID string, accountIDs []string) (*model.RequestParticipantPageScheme, *model.ResponseScheme, error) {
@@ -130,29 +115,19 @@ func (i *internalServiceRequestParticipantImpl) Remove(ctx context.Context, issu
 	if len(accountIDs) == 0 {
 		return nil, nil, model.ErrNoAccountSliceError
 	}
-	payload := struct {
-		AccountIds []string `json:"accountIds"`
-	}{
-		AccountIds: accountIDs,
-	}
-
-	reader, err := i.c.TransformStructToReader(&payload)
-	if err != nil {
-		return nil, nil, err
-	}
 
 	endpoint := fmt.Sprintf("rest/servicedeskapi/request/%v/participant", issueKeyOrID)
 
-	request, err := i.c.NewRequest(ctx, http.MethodDelete, endpoint, reader)
+	req, err := i.c.NewRequest(ctx, http.MethodDelete, endpoint, "", map[string]interface{}{"accountIds": accountIDs})
 	if err != nil {
 		return nil, nil, err
 	}
 
 	page := new(model.RequestParticipantPageScheme)
-	response, err := i.c.Call(request, page)
+	res, err := i.c.Call(req, page)
 	if err != nil {
-		return nil, response, err
+		return nil, res, err
 	}
 
-	return page, response, nil
+	return page, res, nil
 }

--- a/jira/sm/internal/participant_impl_test.go
+++ b/jira/sm/internal/participant_impl_test.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	model "github.com/ctreminiom/go-atlassian/pkg/infra/models"
@@ -15,7 +14,7 @@ import (
 func Test_internalServiceRequestParticipantImpl_Gets(t *testing.T) {
 
 	type fields struct {
-		c service.Client
+		c service.Connector
 	}
 
 	type args struct {
@@ -42,12 +41,13 @@ func Test_internalServiceRequestParticipantImpl_Gets(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodGet,
 					"rest/servicedeskapi/request/DESK-1/participant?limit=50&start=100",
+					"",
 					nil).
 					Return(&http.Request{}, nil)
 
@@ -70,12 +70,13 @@ func Test_internalServiceRequestParticipantImpl_Gets(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodGet,
 					"rest/servicedeskapi/request/DESK-1/participant?limit=50&start=100",
+					"",
 					nil).
 					Return(&http.Request{}, nil)
 
@@ -100,12 +101,13 @@ func Test_internalServiceRequestParticipantImpl_Gets(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodGet,
 					"rest/servicedeskapi/request/DESK-1/participant?limit=50&start=100",
+					"",
 					nil).
 					Return(&http.Request{}, errors.New("client: no http request created"))
 
@@ -132,10 +134,9 @@ func Test_internalServiceRequestParticipantImpl_Gets(t *testing.T) {
 				testCase.on(&testCase.fields)
 			}
 
-			smService, err := NewParticipantService(testCase.fields.c, "latest")
-			assert.NoError(t, err)
+			participantService := NewParticipantService(testCase.fields.c, "latest")
 
-			gotResult, gotResponse, err := smService.Gets(testCase.args.ctx, testCase.args.issueKeyOrID,
+			gotResult, gotResponse, err := participantService.Gets(testCase.args.ctx, testCase.args.issueKeyOrID,
 				testCase.args.start, testCase.args.limit)
 
 			if testCase.wantErr {
@@ -158,12 +159,8 @@ func Test_internalServiceRequestParticipantImpl_Gets(t *testing.T) {
 
 func Test_internalServiceRequestParticipantImpl_Add(t *testing.T) {
 
-	payloadMocked := &struct {
-		AccountIds []string "json:\"accountIds\""
-	}{AccountIds: []string{"uuid-sample-1", "uuid-sample-2"}}
-
 	type fields struct {
-		c service.Client
+		c service.Connector
 	}
 
 	type args struct {
@@ -189,17 +186,14 @@ func Test_internalServiceRequestParticipantImpl_Add(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
-
-				client.On("TransformStructToReader",
-					payloadMocked).
-					Return(bytes.NewReader([]byte{}), nil)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodPost,
 					"rest/servicedeskapi/request/DESK-1/participant",
-					bytes.NewReader([]byte{})).
+					"",
+					map[string]interface{}{"accountIds": []string{"uuid-sample-1", "uuid-sample-2"}}).
 					Return(&http.Request{}, nil)
 
 				client.On("Call",
@@ -220,17 +214,14 @@ func Test_internalServiceRequestParticipantImpl_Add(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
-
-				client.On("TransformStructToReader",
-					payloadMocked).
-					Return(bytes.NewReader([]byte{}), nil)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodPost,
 					"rest/servicedeskapi/request/DESK-1/participant",
-					bytes.NewReader([]byte{})).
+					"",
+					map[string]interface{}{"accountIds": []string{"uuid-sample-1", "uuid-sample-2"}}).
 					Return(&http.Request{}, nil)
 
 				client.On("Call",
@@ -253,17 +244,13 @@ func Test_internalServiceRequestParticipantImpl_Add(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
-
-				client.On("TransformStructToReader",
-					payloadMocked).
-					Return(bytes.NewReader([]byte{}), nil)
-
+				client := mocks.NewConnector(t)
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodPost,
 					"rest/servicedeskapi/request/DESK-1/participant",
-					bytes.NewReader([]byte{})).
+					"",
+					map[string]interface{}{"accountIds": []string{"uuid-sample-1", "uuid-sample-2"}}).
 					Return(&http.Request{}, errors.New("client: no http request created"))
 
 				fields.c = client
@@ -299,10 +286,9 @@ func Test_internalServiceRequestParticipantImpl_Add(t *testing.T) {
 				testCase.on(&testCase.fields)
 			}
 
-			smService, err := NewParticipantService(testCase.fields.c, "latest")
-			assert.NoError(t, err)
+			participantService := NewParticipantService(testCase.fields.c, "latest")
 
-			gotResult, gotResponse, err := smService.Add(testCase.args.ctx, testCase.args.issueKeyOrID, testCase.args.accountIDs)
+			gotResult, gotResponse, err := participantService.Add(testCase.args.ctx, testCase.args.issueKeyOrID, testCase.args.accountIDs)
 
 			if testCase.wantErr {
 
@@ -324,12 +310,8 @@ func Test_internalServiceRequestParticipantImpl_Add(t *testing.T) {
 
 func Test_internalServiceRequestParticipantImpl_Remove(t *testing.T) {
 
-	payloadMocked := &struct {
-		AccountIds []string "json:\"accountIds\""
-	}{AccountIds: []string{"uuid-sample-1", "uuid-sample-2"}}
-
 	type fields struct {
-		c service.Client
+		c service.Connector
 	}
 
 	type args struct {
@@ -355,17 +337,14 @@ func Test_internalServiceRequestParticipantImpl_Remove(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
-
-				client.On("TransformStructToReader",
-					payloadMocked).
-					Return(bytes.NewReader([]byte{}), nil)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodDelete,
 					"rest/servicedeskapi/request/DESK-1/participant",
-					bytes.NewReader([]byte{})).
+					"",
+					map[string]interface{}{"accountIds": []string{"uuid-sample-1", "uuid-sample-2"}}).
 					Return(&http.Request{}, nil)
 
 				client.On("Call",
@@ -386,17 +365,14 @@ func Test_internalServiceRequestParticipantImpl_Remove(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
-
-				client.On("TransformStructToReader",
-					payloadMocked).
-					Return(bytes.NewReader([]byte{}), nil)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodDelete,
 					"rest/servicedeskapi/request/DESK-1/participant",
-					bytes.NewReader([]byte{})).
+					"",
+					map[string]interface{}{"accountIds": []string{"uuid-sample-1", "uuid-sample-2"}}).
 					Return(&http.Request{}, nil)
 
 				client.On("Call",
@@ -419,17 +395,14 @@ func Test_internalServiceRequestParticipantImpl_Remove(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
-
-				client.On("TransformStructToReader",
-					payloadMocked).
-					Return(bytes.NewReader([]byte{}), nil)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodDelete,
 					"rest/servicedeskapi/request/DESK-1/participant",
-					bytes.NewReader([]byte{})).
+					"",
+					map[string]interface{}{"accountIds": []string{"uuid-sample-1", "uuid-sample-2"}}).
 					Return(&http.Request{}, errors.New("client: no http request created"))
 
 				fields.c = client
@@ -465,10 +438,9 @@ func Test_internalServiceRequestParticipantImpl_Remove(t *testing.T) {
 				testCase.on(&testCase.fields)
 			}
 
-			smService, err := NewParticipantService(testCase.fields.c, "latest")
-			assert.NoError(t, err)
+			participantService := NewParticipantService(testCase.fields.c, "latest")
 
-			gotResult, gotResponse, err := smService.Remove(testCase.args.ctx, testCase.args.issueKeyOrID, testCase.args.accountIDs)
+			gotResult, gotResponse, err := participantService.Remove(testCase.args.ctx, testCase.args.issueKeyOrID, testCase.args.accountIDs)
 
 			if testCase.wantErr {
 

--- a/jira/sm/internal/queue_impl.go
+++ b/jira/sm/internal/queue_impl.go
@@ -11,15 +11,11 @@ import (
 	"strconv"
 )
 
-func NewQueueService(client service.Client, version string) (*QueueService, error) {
-
-	if version == "" {
-		return nil, model.ErrNoVersionProvided
-	}
+func NewQueueService(client service.Connector, version string) *QueueService {
 
 	return &QueueService{
 		internalClient: &internalQueueServiceImpl{c: client, version: version},
-	}, nil
+	}
 }
 
 type QueueService struct {
@@ -54,7 +50,7 @@ func (q *QueueService) Issues(ctx context.Context, serviceDeskID, queueID, start
 }
 
 type internalQueueServiceImpl struct {
-	c       service.Client
+	c       service.Connector
 	version string
 }
 
@@ -71,18 +67,18 @@ func (i *internalQueueServiceImpl) Gets(ctx context.Context, serviceDeskID int, 
 
 	endpoint := fmt.Sprintf("rest/servicedeskapi/servicedesk/%v/queue?%v", serviceDeskID, params.Encode())
 
-	request, err := i.c.NewRequest(ctx, http.MethodGet, endpoint, nil)
+	req, err := i.c.NewRequest(ctx, http.MethodGet, endpoint, "", nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	page := new(model.ServiceDeskQueuePageScheme)
-	response, err := i.c.Call(request, page)
+	res, err := i.c.Call(req, page)
 	if err != nil {
-		return nil, response, err
+		return nil, res, err
 	}
 
-	return page, response, nil
+	return page, res, nil
 }
 
 func (i *internalQueueServiceImpl) Get(ctx context.Context, serviceDeskID, queueID int, includeCount bool) (*model.ServiceDeskQueueScheme, *model.ResponseScheme, error) {
@@ -100,18 +96,18 @@ func (i *internalQueueServiceImpl) Get(ctx context.Context, serviceDeskID, queue
 
 	endpoint := fmt.Sprintf("rest/servicedeskapi/servicedesk/%v/queue/%v?%v", serviceDeskID, queueID, params.Encode())
 
-	request, err := i.c.NewRequest(ctx, http.MethodGet, endpoint, nil)
+	req, err := i.c.NewRequest(ctx, http.MethodGet, endpoint, "", nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	queue := new(model.ServiceDeskQueueScheme)
-	response, err := i.c.Call(request, queue)
+	res, err := i.c.Call(req, queue)
 	if err != nil {
-		return nil, response, err
+		return nil, res, err
 	}
 
-	return queue, response, nil
+	return queue, res, nil
 }
 
 func (i *internalQueueServiceImpl) Issues(ctx context.Context, serviceDeskID, queueID, start, limit int) (*model.ServiceDeskIssueQueueScheme, *model.ResponseScheme, error) {
@@ -130,16 +126,16 @@ func (i *internalQueueServiceImpl) Issues(ctx context.Context, serviceDeskID, qu
 
 	endpoint := fmt.Sprintf("rest/servicedeskapi/servicedesk/%v/queue/%v/issue?%v", serviceDeskID, queueID, params.Encode())
 
-	request, err := i.c.NewRequest(ctx, http.MethodGet, endpoint, nil)
+	req, err := i.c.NewRequest(ctx, http.MethodGet, endpoint, "", nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	issues := new(model.ServiceDeskIssueQueueScheme)
-	response, err := i.c.Call(request, issues)
+	res, err := i.c.Call(req, issues)
 	if err != nil {
-		return nil, response, err
+		return nil, res, err
 	}
 
-	return issues, response, nil
+	return issues, res, nil
 }

--- a/jira/sm/internal/queue_impl_test.go
+++ b/jira/sm/internal/queue_impl_test.go
@@ -14,7 +14,7 @@ import (
 func Test_internalQueueServiceImpl_Gets(t *testing.T) {
 
 	type fields struct {
-		c service.Client
+		c service.Connector
 	}
 
 	type args struct {
@@ -43,12 +43,13 @@ func Test_internalQueueServiceImpl_Gets(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodGet,
 					"rest/servicedeskapi/servicedesk/10001/queue?includeCount=true&limit=50&start=100",
+					"",
 					nil).
 					Return(&http.Request{}, nil)
 
@@ -72,12 +73,13 @@ func Test_internalQueueServiceImpl_Gets(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodGet,
 					"rest/servicedeskapi/servicedesk/10001/queue?includeCount=true&limit=50&start=100",
+					"",
 					nil).
 					Return(&http.Request{}, nil)
 
@@ -103,12 +105,13 @@ func Test_internalQueueServiceImpl_Gets(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodGet,
 					"rest/servicedeskapi/servicedesk/10001/queue?includeCount=true&limit=50&start=100",
+					"",
 					nil).
 					Return(&http.Request{}, errors.New("client: no http request created"))
 
@@ -135,10 +138,9 @@ func Test_internalQueueServiceImpl_Gets(t *testing.T) {
 				testCase.on(&testCase.fields)
 			}
 
-			smService, err := NewQueueService(testCase.fields.c, "latest")
-			assert.NoError(t, err)
+			queueService := NewQueueService(testCase.fields.c, "latest")
 
-			gotResult, gotResponse, err := smService.Gets(testCase.args.ctx, testCase.args.serviceDeskID, testCase.args.includeCount,
+			gotResult, gotResponse, err := queueService.Gets(testCase.args.ctx, testCase.args.serviceDeskID, testCase.args.includeCount,
 				testCase.args.start, testCase.args.limit)
 
 			if testCase.wantErr {
@@ -162,7 +164,7 @@ func Test_internalQueueServiceImpl_Gets(t *testing.T) {
 func Test_internalQueueServiceImpl_Get(t *testing.T) {
 
 	type fields struct {
-		c service.Client
+		c service.Connector
 	}
 
 	type args struct {
@@ -190,12 +192,13 @@ func Test_internalQueueServiceImpl_Get(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodGet,
 					"rest/servicedeskapi/servicedesk/10001/queue/29?includeCount=true",
+					"",
 					nil).
 					Return(&http.Request{}, nil)
 
@@ -218,12 +221,13 @@ func Test_internalQueueServiceImpl_Get(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodGet,
 					"rest/servicedeskapi/servicedesk/10001/queue/29?includeCount=true",
+					"",
 					nil).
 					Return(&http.Request{}, nil)
 
@@ -248,12 +252,13 @@ func Test_internalQueueServiceImpl_Get(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodGet,
 					"rest/servicedeskapi/servicedesk/10001/queue/29?includeCount=true",
+					"",
 					nil).
 					Return(&http.Request{}, errors.New("client: no http request created"))
 
@@ -290,10 +295,9 @@ func Test_internalQueueServiceImpl_Get(t *testing.T) {
 				testCase.on(&testCase.fields)
 			}
 
-			smService, err := NewQueueService(testCase.fields.c, "latest")
-			assert.NoError(t, err)
+			queueService := NewQueueService(testCase.fields.c, "latest")
 
-			gotResult, gotResponse, err := smService.Get(testCase.args.ctx, testCase.args.serviceDeskID,
+			gotResult, gotResponse, err := queueService.Get(testCase.args.ctx, testCase.args.serviceDeskID,
 				testCase.args.queueID, testCase.args.includeCount)
 
 			if testCase.wantErr {
@@ -317,7 +321,7 @@ func Test_internalQueueServiceImpl_Get(t *testing.T) {
 func Test_internalQueueServiceImpl_Issues(t *testing.T) {
 
 	type fields struct {
-		c service.Client
+		c service.Connector
 	}
 
 	type args struct {
@@ -348,12 +352,13 @@ func Test_internalQueueServiceImpl_Issues(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodGet,
 					"rest/servicedeskapi/servicedesk/10001/queue/29/issue?limit=50&start=100",
+					"",
 					nil).
 					Return(&http.Request{}, nil)
 
@@ -378,12 +383,13 @@ func Test_internalQueueServiceImpl_Issues(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodGet,
 					"rest/servicedeskapi/servicedesk/10001/queue/29/issue?limit=50&start=100",
+					"",
 					nil).
 					Return(&http.Request{}, nil)
 
@@ -410,12 +416,13 @@ func Test_internalQueueServiceImpl_Issues(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodGet,
 					"rest/servicedeskapi/servicedesk/10001/queue/29/issue?limit=50&start=100",
+					"",
 					nil).
 					Return(&http.Request{}, errors.New("client: no http request created"))
 
@@ -442,10 +449,9 @@ func Test_internalQueueServiceImpl_Issues(t *testing.T) {
 				testCase.on(&testCase.fields)
 			}
 
-			smService, err := NewQueueService(testCase.fields.c, "latest")
-			assert.NoError(t, err)
+			queueService := NewQueueService(testCase.fields.c, "latest")
 
-			gotResult, gotResponse, err := smService.Issues(testCase.args.ctx, testCase.args.serviceDeskID, testCase.args.queueID,
+			gotResult, gotResponse, err := queueService.Issues(testCase.args.ctx, testCase.args.serviceDeskID, testCase.args.queueID,
 				testCase.args.start, testCase.args.limit)
 
 			if testCase.wantErr {

--- a/jira/sm/internal/request_impl_test.go
+++ b/jira/sm/internal/request_impl_test.go
@@ -1,21 +1,22 @@
 package internal
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	model "github.com/ctreminiom/go-atlassian/pkg/infra/models"
 	"github.com/ctreminiom/go-atlassian/service"
 	"github.com/ctreminiom/go-atlassian/service/mocks"
 	"github.com/stretchr/testify/assert"
+	"log"
 	"net/http"
 	"testing"
+	"time"
 )
 
 func Test_internalServiceRequestImpl_Gets(t *testing.T) {
 
 	type fields struct {
-		c service.Client
+		c service.Connector
 	}
 
 	type args struct {
@@ -51,12 +52,13 @@ func Test_internalServiceRequestImpl_Gets(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodGet,
 					"rest/servicedeskapi/request?approvalStatus=MY_PENDING_APPROVAL&expand=serviceDesk%2Caction&limit=50&organizationId=39933&requestOwnership=ORGANIZATION&requestStatus=OPEN_REQUESTS&requestTypeId=1002&searchTerm=IT+Help&serviceDeskId=10002&start=100",
+					"",
 					nil).
 					Return(&http.Request{}, nil)
 
@@ -88,12 +90,13 @@ func Test_internalServiceRequestImpl_Gets(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodGet,
 					"rest/servicedeskapi/request?approvalStatus=MY_PENDING_APPROVAL&expand=serviceDesk%2Caction&limit=50&organizationId=39933&requestOwnership=ORGANIZATION&requestStatus=OPEN_REQUESTS&requestTypeId=1002&searchTerm=IT+Help&serviceDeskId=10002&start=100",
+					"",
 					nil).
 					Return(&http.Request{}, nil)
 
@@ -127,12 +130,13 @@ func Test_internalServiceRequestImpl_Gets(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodGet,
 					"rest/servicedeskapi/request?approvalStatus=MY_PENDING_APPROVAL&expand=serviceDesk%2Caction&limit=50&organizationId=39933&requestOwnership=ORGANIZATION&requestStatus=OPEN_REQUESTS&requestTypeId=1002&searchTerm=IT+Help&serviceDeskId=10002&start=100",
+					"",
 					nil).
 					Return(&http.Request{}, errors.New("client: no http request created"))
 
@@ -177,7 +181,7 @@ func Test_internalServiceRequestImpl_Gets(t *testing.T) {
 func Test_internalServiceRequestImpl_Transitions(t *testing.T) {
 
 	type fields struct {
-		c service.Client
+		c service.Connector
 	}
 
 	type args struct {
@@ -204,12 +208,13 @@ func Test_internalServiceRequestImpl_Transitions(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodGet,
 					"rest/servicedeskapi/request/DESK-1/transition?limit=50&start=100",
+					"",
 					nil).
 					Return(&http.Request{}, nil)
 
@@ -232,12 +237,13 @@ func Test_internalServiceRequestImpl_Transitions(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodGet,
 					"rest/servicedeskapi/request/DESK-1/transition?limit=50&start=100",
+					"",
 					nil).
 					Return(&http.Request{}, nil)
 
@@ -262,12 +268,13 @@ func Test_internalServiceRequestImpl_Transitions(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodGet,
 					"rest/servicedeskapi/request/DESK-1/transition?limit=50&start=100",
+					"",
 					nil).
 					Return(&http.Request{}, errors.New("client: no http request created"))
 
@@ -321,7 +328,7 @@ func Test_internalServiceRequestImpl_Transitions(t *testing.T) {
 func Test_internalServiceRequestImpl_Get(t *testing.T) {
 
 	type fields struct {
-		c service.Client
+		c service.Connector
 	}
 
 	type args struct {
@@ -347,12 +354,13 @@ func Test_internalServiceRequestImpl_Get(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodGet,
 					"rest/servicedeskapi/request/DESK-1?expand=serviceDesk",
+					"",
 					nil).
 					Return(&http.Request{}, nil)
 
@@ -374,12 +382,13 @@ func Test_internalServiceRequestImpl_Get(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodGet,
 					"rest/servicedeskapi/request/DESK-1?expand=serviceDesk",
+					"",
 					nil).
 					Return(&http.Request{}, nil)
 
@@ -403,12 +412,13 @@ func Test_internalServiceRequestImpl_Get(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodGet,
 					"rest/servicedeskapi/request/DESK-1?expand=serviceDesk",
+					"",
 					nil).
 					Return(&http.Request{}, errors.New("client: no http request created"))
 
@@ -461,7 +471,7 @@ func Test_internalServiceRequestImpl_Get(t *testing.T) {
 func Test_internalServiceRequestImpl_Subscribe(t *testing.T) {
 
 	type fields struct {
-		c service.Client
+		c service.Connector
 	}
 
 	type args struct {
@@ -485,12 +495,13 @@ func Test_internalServiceRequestImpl_Subscribe(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodPut,
 					"rest/servicedeskapi/request/DESK-1/notification",
+					"",
 					nil).
 					Return(&http.Request{}, nil)
 
@@ -511,12 +522,13 @@ func Test_internalServiceRequestImpl_Subscribe(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodPut,
 					"rest/servicedeskapi/request/DESK-1/notification",
+					"",
 					nil).
 					Return(&http.Request{}, nil)
 
@@ -539,12 +551,13 @@ func Test_internalServiceRequestImpl_Subscribe(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodPut,
 					"rest/servicedeskapi/request/DESK-1/notification",
+					"",
 					nil).
 					Return(&http.Request{}, errors.New("client: no http request created"))
 
@@ -596,7 +609,7 @@ func Test_internalServiceRequestImpl_Subscribe(t *testing.T) {
 func Test_internalServiceRequestImpl_Unsubscribe(t *testing.T) {
 
 	type fields struct {
-		c service.Client
+		c service.Connector
 	}
 
 	type args struct {
@@ -620,12 +633,13 @@ func Test_internalServiceRequestImpl_Unsubscribe(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodDelete,
 					"rest/servicedeskapi/request/DESK-1/notification",
+					"",
 					nil).
 					Return(&http.Request{}, nil)
 
@@ -646,12 +660,13 @@ func Test_internalServiceRequestImpl_Unsubscribe(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodDelete,
 					"rest/servicedeskapi/request/DESK-1/notification",
+					"",
 					nil).
 					Return(&http.Request{}, nil)
 
@@ -674,12 +689,13 @@ func Test_internalServiceRequestImpl_Unsubscribe(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodDelete,
 					"rest/servicedeskapi/request/DESK-1/notification",
+					"",
 					nil).
 					Return(&http.Request{}, errors.New("client: no http request created"))
 
@@ -730,17 +746,8 @@ func Test_internalServiceRequestImpl_Unsubscribe(t *testing.T) {
 
 func Test_internalServiceRequestImpl_Transition(t *testing.T) {
 
-	payloadMocked := &struct {
-		ID                string "json:\"id\""
-		AdditionalComment struct {
-			Body string "json:\"body,omitempty\""
-		} "json:\"additionalComment,omitempty\""
-	}{ID: "299991", AdditionalComment: struct {
-		Body string "json:\"body,omitempty\""
-	}{Body: "Hello there!"}}
-
 	type fields struct {
-		c service.Client
+		c service.Connector
 	}
 
 	type args struct {
@@ -762,21 +769,46 @@ func Test_internalServiceRequestImpl_Transition(t *testing.T) {
 				ctx:          context.Background(),
 				issueKeyOrID: "DESK-1",
 				transitionID: "299991",
-				comment:      "Hello there!",
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
-
-				client.On("TransformStructToReader",
-					payloadMocked).
-					Return(bytes.NewReader([]byte{}), nil)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodPost,
 					"rest/servicedeskapi/request/DESK-1/transition",
-					bytes.NewReader([]byte{})).
+					"",
+					map[string]interface{}{"id": "299991"}).
+					Return(&http.Request{}, nil)
+
+				client.On("Call",
+					&http.Request{},
+					nil).
+					Return(&model.ResponseScheme{}, nil)
+
+				fields.c = client
+			},
+		},
+
+		{
+			name: "when the comment is provided",
+			args: args{
+				ctx:          context.Background(),
+				issueKeyOrID: "DESK-1",
+				transitionID: "299991",
+				comment:      "Hello there!",
+			},
+			on: func(fields *fields) {
+
+				client := mocks.NewConnector(t)
+
+				client.On("NewRequest",
+					context.Background(),
+					http.MethodPost,
+					"rest/servicedeskapi/request/DESK-1/transition",
+					"",
+					map[string]interface{}{"additionalComment": map[string]interface{}{"body": "Hello there!"}, "id": "299991"}).
 					Return(&http.Request{}, nil)
 
 				client.On("Call",
@@ -798,17 +830,14 @@ func Test_internalServiceRequestImpl_Transition(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
-
-				client.On("TransformStructToReader",
-					payloadMocked).
-					Return(bytes.NewReader([]byte{}), nil)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodPost,
 					"rest/servicedeskapi/request/DESK-1/transition",
-					bytes.NewReader([]byte{})).
+					"",
+					map[string]interface{}{"additionalComment": map[string]interface{}{"body": "Hello there!"}, "id": "299991"}).
 					Return(&http.Request{}, nil)
 
 				client.On("Call",
@@ -832,17 +861,14 @@ func Test_internalServiceRequestImpl_Transition(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
-
-				client.On("TransformStructToReader",
-					payloadMocked).
-					Return(bytes.NewReader([]byte{}), nil)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodPost,
 					"rest/servicedeskapi/request/DESK-1/transition",
-					bytes.NewReader([]byte{})).
+					"",
+					map[string]interface{}{"additionalComment": map[string]interface{}{"body": "Hello there!"}, "id": "299991"}).
 					Return(&http.Request{}, errors.New("client: no http request created"))
 
 				fields.c = client
@@ -903,15 +929,7 @@ func Test_internalServiceRequestImpl_Transition(t *testing.T) {
 
 func Test_internalServiceRequestImpl_Create(t *testing.T) {
 
-	payloadMocked := &map[string]interface{}{
-		"requestFieldValues": map[string]interface{}{
-			"description": "I need a new *mouse* for my Mac", "summary": "Request JSD help via REST"},
-		"requestParticipants": []interface{}{
-			"uuid-sample-1", "uuid-sample-2"},
-		"requestTypeId": "28881",
-		"serviceDeskId": "29990"}
-
-	fieldsMocked := &model.CustomerRequestFields{}
+	fieldsMocked := &model.CustomerRequestFields{Fields: make(map[string]interface{})}
 
 	if err := fieldsMocked.Text("summary", "Request JSD help via REST"); err != nil {
 		t.Fatal(err)
@@ -921,8 +939,41 @@ func Test_internalServiceRequestImpl_Create(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	if err := fieldsMocked.Select("priority", "Major"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := fieldsMocked.Components([]string{"Jira", "Intranet"}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := fieldsMocked.Users("customfield_320239", []string{"account-id-sample"}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := fieldsMocked.Date("duedate", time.Now()); err != nil {
+		log.Fatal(err)
+	}
+
+	if err := fieldsMocked.Labels([]string{"label-00", "label-01"}); err != nil {
+		log.Fatal(err)
+	}
+
+	payloadMocked := map[string]interface{}{
+		"requestFieldValues": map[string]interface{}{
+			"components":         []map[string]interface{}{map[string]interface{}{"name": "Jira"}, map[string]interface{}{"name": "Intranet"}},
+			"customfield_320239": []map[string]interface{}{map[string]interface{}{"accountId": "account-id-sample"}},
+			"description":        "I need a new *mouse* for my Mac",
+			"duedate":            "2023-06-21",
+			"labels":             []string{"label-00", "label-01"},
+			"priority":           map[string]interface{}{"value": "Major"},
+			"summary":            "Request JSD help via REST"},
+		"requestParticipants": []interface{}{"uuid-sample-1", "uuid-sample-2"},
+		"requestTypeId":       "28881",
+		"serviceDeskId":       "29990"}
+
 	type fields struct {
-		c service.Client
+		c service.Connector
 	}
 
 	type args struct {
@@ -952,17 +1003,14 @@ func Test_internalServiceRequestImpl_Create(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
-
-				client.On("TransformStructToReader",
-					payloadMocked).
-					Return(bytes.NewReader([]byte{}), nil)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodPost,
 					"rest/servicedeskapi/request",
-					bytes.NewReader([]byte{})).
+					"",
+					payloadMocked).
 					Return(&http.Request{}, nil)
 
 				client.On("Call",
@@ -987,17 +1035,14 @@ func Test_internalServiceRequestImpl_Create(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
-
-				client.On("TransformStructToReader",
-					payloadMocked).
-					Return(bytes.NewReader([]byte{}), nil)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodPost,
 					"rest/servicedeskapi/request",
-					bytes.NewReader([]byte{})).
+					"",
+					payloadMocked).
 					Return(&http.Request{}, nil)
 
 				client.On("Call",
@@ -1024,17 +1069,14 @@ func Test_internalServiceRequestImpl_Create(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
-
-				client.On("TransformStructToReader",
-					payloadMocked).
-					Return(bytes.NewReader([]byte{}), nil)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodPost,
 					"rest/servicedeskapi/request",
-					bytes.NewReader([]byte{})).
+					"",
+					payloadMocked).
 					Return(&http.Request{}, errors.New("client: no http request created"))
 
 				fields.c = client

--- a/jira/sm/internal/request_impl_test.go
+++ b/jira/sm/internal/request_impl_test.go
@@ -951,7 +951,7 @@ func Test_internalServiceRequestImpl_Create(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := fieldsMocked.Date("duedate", time.Now()); err != nil {
+	if err := fieldsMocked.Date("duedate", time.Date(2020, 1, 2, 3, 4, 5, 0, time.UTC)); err != nil {
 		log.Fatal(err)
 	}
 
@@ -964,7 +964,7 @@ func Test_internalServiceRequestImpl_Create(t *testing.T) {
 			"components":         []map[string]interface{}{map[string]interface{}{"name": "Jira"}, map[string]interface{}{"name": "Intranet"}},
 			"customfield_320239": []map[string]interface{}{map[string]interface{}{"accountId": "account-id-sample"}},
 			"description":        "I need a new *mouse* for my Mac",
-			"duedate":            "2023-06-21",
+			"duedate":            "2020-01-02",
 			"labels":             []string{"label-00", "label-01"},
 			"priority":           map[string]interface{}{"value": "Major"},
 			"summary":            "Request JSD help via REST"},

--- a/jira/sm/internal/service_desk_impl_test.go
+++ b/jira/sm/internal/service_desk_impl_test.go
@@ -18,7 +18,7 @@ import (
 func Test_internalServiceDeskImpl_Gets(t *testing.T) {
 
 	type fields struct {
-		c service.Client
+		c service.Connector
 	}
 
 	type args struct {
@@ -43,12 +43,13 @@ func Test_internalServiceDeskImpl_Gets(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodGet,
 					"rest/servicedeskapi/servicedesk?limit=50&start=100",
+					"",
 					nil).
 					Return(&http.Request{}, nil)
 
@@ -70,12 +71,13 @@ func Test_internalServiceDeskImpl_Gets(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodGet,
 					"rest/servicedeskapi/servicedesk?limit=50&start=100",
+					"",
 					nil).
 					Return(&http.Request{}, nil)
 
@@ -99,12 +101,13 @@ func Test_internalServiceDeskImpl_Gets(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodGet,
 					"rest/servicedeskapi/servicedesk?limit=50&start=100",
+					"",
 					nil).
 					Return(&http.Request{}, errors.New("client: no http request created"))
 
@@ -148,7 +151,7 @@ func Test_internalServiceDeskImpl_Gets(t *testing.T) {
 func Test_internalServiceDeskImpl_Get(t *testing.T) {
 
 	type fields struct {
-		c service.Client
+		c service.Connector
 	}
 
 	type args struct {
@@ -172,12 +175,13 @@ func Test_internalServiceDeskImpl_Get(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodGet,
 					"rest/servicedeskapi/servicedesk/10001",
+					"",
 					nil).
 					Return(&http.Request{}, nil)
 
@@ -198,12 +202,13 @@ func Test_internalServiceDeskImpl_Get(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodGet,
 					"rest/servicedeskapi/servicedesk/10001",
+					"",
 					nil).
 					Return(&http.Request{}, nil)
 
@@ -226,12 +231,13 @@ func Test_internalServiceDeskImpl_Get(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodGet,
 					"rest/servicedeskapi/servicedesk/10001",
+					"",
 					nil).
 					Return(&http.Request{}, errors.New("client: no http request created"))
 
@@ -294,7 +300,7 @@ func Test_internalServiceDeskImpl_Attach(t *testing.T) {
 	}
 
 	type fields struct {
-		c service.Client
+		c service.Connector
 	}
 
 	type args struct {
@@ -322,13 +328,13 @@ func Test_internalServiceDeskImpl_Attach(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
+				client := mocks.NewConnector(t)
 
-				client.On("NewFormRequest",
+				client.On("NewRequest",
 					context.Background(),
 					http.MethodPost,
 					"rest/servicedeskapi/servicedesk/10001/attachTemporaryFile",
-					mock.Anything,
+					mock.AnythingOfType("string"),
 					mock.Anything).
 					Return(&http.Request{}, nil)
 
@@ -351,13 +357,13 @@ func Test_internalServiceDeskImpl_Attach(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
+				client := mocks.NewConnector(t)
 
-				client.On("NewFormRequest",
+				client.On("NewRequest",
 					context.Background(),
 					http.MethodPost,
 					"rest/servicedeskapi/servicedesk/10001/attachTemporaryFile",
-					mock.Anything,
+					mock.AnythingOfType("string"),
 					mock.Anything).
 					Return(&http.Request{}, nil)
 
@@ -382,13 +388,13 @@ func Test_internalServiceDeskImpl_Attach(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
+				client := mocks.NewConnector(t)
 
-				client.On("NewFormRequest",
+				client.On("NewRequest",
 					context.Background(),
 					http.MethodPost,
 					"rest/servicedeskapi/servicedesk/10001/attachTemporaryFile",
-					mock.Anything,
+					mock.AnythingOfType("string"),
 					mock.Anything).
 					Return(&http.Request{}, errors.New("client: no http request created"))
 

--- a/jira/sm/internal/sla_impl.go
+++ b/jira/sm/internal/sla_impl.go
@@ -11,15 +11,11 @@ import (
 	"strconv"
 )
 
-func NewServiceLevelAgreementService(client service.Client, version string) (*ServiceLevelAgreementService, error) {
-
-	if version == "" {
-		return nil, model.ErrNoVersionProvided
-	}
+func NewServiceLevelAgreementService(client service.Connector, version string) *ServiceLevelAgreementService {
 
 	return &ServiceLevelAgreementService{
 		internalClient: &internalServiceLevelAgreementImpl{c: client, version: version},
-	}, nil
+	}
 }
 
 type ServiceLevelAgreementService struct {
@@ -47,7 +43,7 @@ func (s *ServiceLevelAgreementService) Get(ctx context.Context, issueKeyOrID str
 }
 
 type internalServiceLevelAgreementImpl struct {
-	c       service.Client
+	c       service.Connector
 	version string
 }
 
@@ -63,18 +59,18 @@ func (i *internalServiceLevelAgreementImpl) Gets(ctx context.Context, issueKeyOr
 
 	endpoint := fmt.Sprintf("rest/servicedeskapi/request/%v/sla?%v", issueKeyOrID, params.Encode())
 
-	request, err := i.c.NewRequest(ctx, http.MethodGet, endpoint, nil)
+	req, err := i.c.NewRequest(ctx, http.MethodGet, endpoint, "", nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	page := new(model.RequestSLAPageScheme)
-	response, err := i.c.Call(request, page)
+	res, err := i.c.Call(req, page)
 	if err != nil {
-		return nil, response, err
+		return nil, res, err
 	}
 
-	return page, response, nil
+	return page, res, nil
 }
 
 func (i *internalServiceLevelAgreementImpl) Get(ctx context.Context, issueKeyOrID string, metricID int) (*model.RequestSLAScheme, *model.ResponseScheme, error) {
@@ -89,16 +85,16 @@ func (i *internalServiceLevelAgreementImpl) Get(ctx context.Context, issueKeyOrI
 
 	endpoint := fmt.Sprintf("rest/servicedeskapi/request/%v/sla/%v", issueKeyOrID, metricID)
 
-	request, err := i.c.NewRequest(ctx, http.MethodGet, endpoint, nil)
+	req, err := i.c.NewRequest(ctx, http.MethodGet, endpoint, "", nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	sla := new(model.RequestSLAScheme)
-	response, err := i.c.Call(request, sla)
+	res, err := i.c.Call(req, sla)
 	if err != nil {
-		return nil, response, err
+		return nil, res, err
 	}
 
-	return sla, response, nil
+	return sla, res, nil
 }

--- a/jira/sm/internal/sla_impl_test.go
+++ b/jira/sm/internal/sla_impl_test.go
@@ -14,7 +14,7 @@ import (
 func Test_internalServiceLevelAgreementImpl_Gets(t *testing.T) {
 
 	type fields struct {
-		c service.Client
+		c service.Connector
 	}
 
 	type args struct {
@@ -41,12 +41,13 @@ func Test_internalServiceLevelAgreementImpl_Gets(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodGet,
 					"rest/servicedeskapi/request/DESK-1/sla?limit=50&start=100",
+					"",
 					nil).
 					Return(&http.Request{}, nil)
 
@@ -69,12 +70,13 @@ func Test_internalServiceLevelAgreementImpl_Gets(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodGet,
 					"rest/servicedeskapi/request/DESK-1/sla?limit=50&start=100",
+					"",
 					nil).
 					Return(&http.Request{}, nil)
 
@@ -99,12 +101,13 @@ func Test_internalServiceLevelAgreementImpl_Gets(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodGet,
 					"rest/servicedeskapi/request/DESK-1/sla?limit=50&start=100",
+					"",
 					nil).
 					Return(&http.Request{}, errors.New("client: no http request created"))
 
@@ -131,10 +134,9 @@ func Test_internalServiceLevelAgreementImpl_Gets(t *testing.T) {
 				testCase.on(&testCase.fields)
 			}
 
-			smService, err := NewServiceLevelAgreementService(testCase.fields.c, "latest")
-			assert.NoError(t, err)
+			slaService := NewServiceLevelAgreementService(testCase.fields.c, "latest")
 
-			gotResult, gotResponse, err := smService.Gets(testCase.args.ctx, testCase.args.issueKeyOrID, testCase.args.start,
+			gotResult, gotResponse, err := slaService.Gets(testCase.args.ctx, testCase.args.issueKeyOrID, testCase.args.start,
 				testCase.args.limit)
 
 			if testCase.wantErr {
@@ -158,7 +160,7 @@ func Test_internalServiceLevelAgreementImpl_Gets(t *testing.T) {
 func Test_internalServiceLevelAgreementImpl_Get(t *testing.T) {
 
 	type fields struct {
-		c service.Client
+		c service.Connector
 	}
 
 	type args struct {
@@ -184,12 +186,13 @@ func Test_internalServiceLevelAgreementImpl_Get(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodGet,
 					"rest/servicedeskapi/request/DESK-1/sla/1999",
+					"",
 					nil).
 					Return(&http.Request{}, nil)
 
@@ -211,12 +214,13 @@ func Test_internalServiceLevelAgreementImpl_Get(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodGet,
 					"rest/servicedeskapi/request/DESK-1/sla/1999",
+					"",
 					nil).
 					Return(&http.Request{}, nil)
 
@@ -240,12 +244,13 @@ func Test_internalServiceLevelAgreementImpl_Get(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodGet,
 					"rest/servicedeskapi/request/DESK-1/sla/1999",
+					"",
 					nil).
 					Return(&http.Request{}, errors.New("client: no http request created"))
 
@@ -282,10 +287,9 @@ func Test_internalServiceLevelAgreementImpl_Get(t *testing.T) {
 				testCase.on(&testCase.fields)
 			}
 
-			smService, err := NewServiceLevelAgreementService(testCase.fields.c, "latest")
-			assert.NoError(t, err)
+			slaService := NewServiceLevelAgreementService(testCase.fields.c, "latest")
 
-			gotResult, gotResponse, err := smService.Get(testCase.args.ctx, testCase.args.issueKeyOrID, testCase.args.metricID)
+			gotResult, gotResponse, err := slaService.Get(testCase.args.ctx, testCase.args.issueKeyOrID, testCase.args.metricID)
 
 			if testCase.wantErr {
 

--- a/jira/sm/internal/type_impl_test.go
+++ b/jira/sm/internal/type_impl_test.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	model "github.com/ctreminiom/go-atlassian/pkg/infra/models"
@@ -15,7 +14,7 @@ import (
 func Test_internalTypeImpl_Search(t *testing.T) {
 
 	type fields struct {
-		c service.Client
+		c service.Connector
 	}
 
 	type args struct {
@@ -42,12 +41,13 @@ func Test_internalTypeImpl_Search(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodGet,
 					"rest/servicedeskapi/requesttype?limit=50&searchQuery=Request+Testing+Environment&start=100",
+					"",
 					nil).
 					Return(&http.Request{}, nil)
 
@@ -70,12 +70,13 @@ func Test_internalTypeImpl_Search(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodGet,
 					"rest/servicedeskapi/requesttype?limit=50&searchQuery=Request+Testing+Environment&start=100",
+					"",
 					nil).
 					Return(&http.Request{}, nil)
 
@@ -100,12 +101,13 @@ func Test_internalTypeImpl_Search(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodGet,
 					"rest/servicedeskapi/requesttype?limit=50&searchQuery=Request+Testing+Environment&start=100",
+					"",
 					nil).
 					Return(&http.Request{}, errors.New("client: no http request created"))
 
@@ -123,10 +125,9 @@ func Test_internalTypeImpl_Search(t *testing.T) {
 				testCase.on(&testCase.fields)
 			}
 
-			smService, err := NewTypeService(testCase.fields.c, "latest")
-			assert.NoError(t, err)
+			requestTypeSchemer := NewTypeService(testCase.fields.c, "latest")
 
-			gotResult, gotResponse, err := smService.Search(testCase.args.ctx, testCase.args.query, testCase.args.start,
+			gotResult, gotResponse, err := requestTypeSchemer.Search(testCase.args.ctx, testCase.args.query, testCase.args.start,
 				testCase.args.limit)
 
 			if testCase.wantErr {
@@ -150,7 +151,7 @@ func Test_internalTypeImpl_Search(t *testing.T) {
 func Test_internalTypeImpl_Gets(t *testing.T) {
 
 	type fields struct {
-		c service.Client
+		c service.Connector
 	}
 
 	type args struct {
@@ -178,12 +179,13 @@ func Test_internalTypeImpl_Gets(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodGet,
 					"rest/servicedeskapi/servicedesk/10001/requesttype?groupId=38383&limit=50&start=100",
+					"",
 					nil).
 					Return(&http.Request{}, nil)
 
@@ -207,12 +209,13 @@ func Test_internalTypeImpl_Gets(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodGet,
 					"rest/servicedeskapi/servicedesk/10001/requesttype?groupId=38383&limit=50&start=100",
+					"",
 					nil).
 					Return(&http.Request{}, nil)
 
@@ -238,12 +241,13 @@ func Test_internalTypeImpl_Gets(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodGet,
 					"rest/servicedeskapi/servicedesk/10001/requesttype?groupId=38383&limit=50&start=100",
+					"",
 					nil).
 					Return(&http.Request{}, errors.New("client: no http request created"))
 
@@ -270,10 +274,9 @@ func Test_internalTypeImpl_Gets(t *testing.T) {
 				testCase.on(&testCase.fields)
 			}
 
-			smService, err := NewTypeService(testCase.fields.c, "latest")
-			assert.NoError(t, err)
+			requestTypeService := NewTypeService(testCase.fields.c, "latest")
 
-			gotResult, gotResponse, err := smService.Gets(testCase.args.ctx, testCase.args.serviceDeskID,
+			gotResult, gotResponse, err := requestTypeService.Gets(testCase.args.ctx, testCase.args.serviceDeskID,
 				testCase.args.groupID, testCase.args.start, testCase.args.limit)
 
 			if testCase.wantErr {
@@ -297,7 +300,7 @@ func Test_internalTypeImpl_Gets(t *testing.T) {
 func Test_internalTypeImpl_Get(t *testing.T) {
 
 	type fields struct {
-		c service.Client
+		c service.Connector
 	}
 
 	type args struct {
@@ -322,12 +325,13 @@ func Test_internalTypeImpl_Get(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodGet,
 					"rest/servicedeskapi/servicedesk/10001/requesttype/38383",
+					"",
 					nil).
 					Return(&http.Request{}, nil)
 
@@ -349,12 +353,13 @@ func Test_internalTypeImpl_Get(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodGet,
 					"rest/servicedeskapi/servicedesk/10001/requesttype/38383",
+					"",
 					nil).
 					Return(&http.Request{}, nil)
 
@@ -378,12 +383,13 @@ func Test_internalTypeImpl_Get(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodGet,
 					"rest/servicedeskapi/servicedesk/10001/requesttype/38383",
+					"",
 					nil).
 					Return(&http.Request{}, errors.New("client: no http request created"))
 
@@ -420,10 +426,9 @@ func Test_internalTypeImpl_Get(t *testing.T) {
 				testCase.on(&testCase.fields)
 			}
 
-			smService, err := NewTypeService(testCase.fields.c, "latest")
-			assert.NoError(t, err)
+			requestTypeService := NewTypeService(testCase.fields.c, "latest")
 
-			gotResult, gotResponse, err := smService.Get(testCase.args.ctx, testCase.args.serviceDeskID,
+			gotResult, gotResponse, err := requestTypeService.Get(testCase.args.ctx, testCase.args.serviceDeskID,
 				testCase.args.requestTypeID)
 
 			if testCase.wantErr {
@@ -447,7 +452,7 @@ func Test_internalTypeImpl_Get(t *testing.T) {
 func Test_internalTypeImpl_Fields(t *testing.T) {
 
 	type fields struct {
-		c service.Client
+		c service.Connector
 	}
 
 	type args struct {
@@ -472,12 +477,13 @@ func Test_internalTypeImpl_Fields(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodGet,
 					"rest/servicedeskapi/servicedesk/10001/requesttype/38383/field",
+					"",
 					nil).
 					Return(&http.Request{}, nil)
 
@@ -499,12 +505,13 @@ func Test_internalTypeImpl_Fields(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodGet,
 					"rest/servicedeskapi/servicedesk/10001/requesttype/38383/field",
+					"",
 					nil).
 					Return(&http.Request{}, nil)
 
@@ -528,12 +535,13 @@ func Test_internalTypeImpl_Fields(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodGet,
 					"rest/servicedeskapi/servicedesk/10001/requesttype/38383/field",
+					"",
 					nil).
 					Return(&http.Request{}, errors.New("client: no http request created"))
 
@@ -570,10 +578,9 @@ func Test_internalTypeImpl_Fields(t *testing.T) {
 				testCase.on(&testCase.fields)
 			}
 
-			smService, err := NewTypeService(testCase.fields.c, "latest")
-			assert.NoError(t, err)
+			requestTypeService := NewTypeService(testCase.fields.c, "latest")
 
-			gotResult, gotResponse, err := smService.Fields(testCase.args.ctx, testCase.args.serviceDeskID,
+			gotResult, gotResponse, err := requestTypeService.Fields(testCase.args.ctx, testCase.args.serviceDeskID,
 				testCase.args.requestTypeID)
 
 			if testCase.wantErr {
@@ -597,7 +604,7 @@ func Test_internalTypeImpl_Fields(t *testing.T) {
 func Test_internalTypeImpl_Delete(t *testing.T) {
 
 	type fields struct {
-		c service.Client
+		c service.Connector
 	}
 
 	type args struct {
@@ -622,12 +629,13 @@ func Test_internalTypeImpl_Delete(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodDelete,
 					"rest/servicedeskapi/servicedesk/10001/requesttype/38383",
+					"",
 					nil).
 					Return(&http.Request{}, nil)
 
@@ -649,12 +657,13 @@ func Test_internalTypeImpl_Delete(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodDelete,
 					"rest/servicedeskapi/servicedesk/10001/requesttype/38383",
+					"",
 					nil).
 					Return(&http.Request{}, nil)
 
@@ -678,12 +687,13 @@ func Test_internalTypeImpl_Delete(t *testing.T) {
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodDelete,
 					"rest/servicedeskapi/servicedesk/10001/requesttype/38383",
+					"",
 					nil).
 					Return(&http.Request{}, errors.New("client: no http request created"))
 
@@ -720,10 +730,9 @@ func Test_internalTypeImpl_Delete(t *testing.T) {
 				testCase.on(&testCase.fields)
 			}
 
-			smService, err := NewTypeService(testCase.fields.c, "latest")
-			assert.NoError(t, err)
+			requestTypeService := NewTypeService(testCase.fields.c, "latest")
 
-			gotResponse, err := smService.Delete(testCase.args.ctx, testCase.args.serviceDeskID,
+			gotResponse, err := requestTypeService.Delete(testCase.args.ctx, testCase.args.serviceDeskID,
 				testCase.args.requestTypeID)
 
 			if testCase.wantErr {
@@ -745,21 +754,20 @@ func Test_internalTypeImpl_Delete(t *testing.T) {
 
 func Test_internalTypeImpl_Create(t *testing.T) {
 
-	payloadMocked := &struct {
-		IssueTypeID string "json:\"issueTypeId,omitempty\""
-		HelpText    string "json:\"helpText,omitempty\""
-		Name        string "json:\"name,omitempty\""
-		Description string "json:\"description,omitempty\""
-	}{IssueTypeID: "12345", HelpText: "Please tell us clearly the problem you have within 100 words.", Name: "Get IT Help", Description: "Get IT Help"}
+	payloadMocked := &model.RequestTypePayloadScheme{
+		Description: "Get IT Help",
+		HelpText:    "Please tell us clearly the problem you have within 100 words.",
+		IssueTypeId: "12345",
+		Name:        "Get IT Help"}
 
 	type fields struct {
-		c service.Client
+		c service.Connector
 	}
 
 	type args struct {
-		ctx                                      context.Context
-		serviceDeskID                            int
-		issueTypeID, name, description, helpText string
+		ctx           context.Context
+		serviceDeskID int
+		payload       *model.RequestTypePayloadScheme
 	}
 
 	testCases := []struct {
@@ -775,24 +783,23 @@ func Test_internalTypeImpl_Create(t *testing.T) {
 			args: args{
 				ctx:           context.Background(),
 				serviceDeskID: 10001,
-				issueTypeID:   "12345",
-				name:          "Get IT Help",
-				description:   "Get IT Help",
-				helpText:      "Please tell us clearly the problem you have within 100 words.",
+				payload: &model.RequestTypePayloadScheme{
+					Description: "Get IT Help",
+					HelpText:    "Please tell us clearly the problem you have within 100 words.",
+					IssueTypeId: "12345",
+					Name:        "Get IT Help",
+				},
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
-
-				client.On("TransformStructToReader",
-					payloadMocked).
-					Return(bytes.NewReader([]byte{}), nil)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodPost,
 					"rest/servicedeskapi/servicedesk/10001/requesttype",
-					bytes.NewReader([]byte{})).
+					"",
+					payloadMocked).
 					Return(&http.Request{}, nil)
 
 				client.On("Call",
@@ -809,24 +816,23 @@ func Test_internalTypeImpl_Create(t *testing.T) {
 			args: args{
 				ctx:           context.Background(),
 				serviceDeskID: 10001,
-				issueTypeID:   "12345",
-				name:          "Get IT Help",
-				description:   "Get IT Help",
-				helpText:      "Please tell us clearly the problem you have within 100 words.",
+				payload: &model.RequestTypePayloadScheme{
+					Description: "Get IT Help",
+					HelpText:    "Please tell us clearly the problem you have within 100 words.",
+					IssueTypeId: "12345",
+					Name:        "Get IT Help",
+				},
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
-
-				client.On("TransformStructToReader",
-					payloadMocked).
-					Return(bytes.NewReader([]byte{}), nil)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodPost,
 					"rest/servicedeskapi/servicedesk/10001/requesttype",
-					bytes.NewReader([]byte{})).
+					"",
+					payloadMocked).
 					Return(&http.Request{}, nil)
 
 				client.On("Call",
@@ -845,24 +851,23 @@ func Test_internalTypeImpl_Create(t *testing.T) {
 			args: args{
 				ctx:           context.Background(),
 				serviceDeskID: 10001,
-				issueTypeID:   "12345",
-				name:          "Get IT Help",
-				description:   "Get IT Help",
-				helpText:      "Please tell us clearly the problem you have within 100 words.",
+				payload: &model.RequestTypePayloadScheme{
+					Description: "Get IT Help",
+					HelpText:    "Please tell us clearly the problem you have within 100 words.",
+					IssueTypeId: "12345",
+					Name:        "Get IT Help",
+				},
 			},
 			on: func(fields *fields) {
 
-				client := mocks.NewClient(t)
-
-				client.On("TransformStructToReader",
-					payloadMocked).
-					Return(bytes.NewReader([]byte{}), nil)
+				client := mocks.NewConnector(t)
 
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodPost,
 					"rest/servicedeskapi/servicedesk/10001/requesttype",
-					bytes.NewReader([]byte{})).
+					"",
+					payloadMocked).
 					Return(&http.Request{}, errors.New("client: no http request created"))
 
 				fields.c = client
@@ -888,11 +893,10 @@ func Test_internalTypeImpl_Create(t *testing.T) {
 				testCase.on(&testCase.fields)
 			}
 
-			smService, err := NewTypeService(testCase.fields.c, "latest")
-			assert.NoError(t, err)
+			requestTypeService := NewTypeService(testCase.fields.c, "latest")
 
-			gotResult, gotResponse, err := smService.Create(testCase.args.ctx, testCase.args.serviceDeskID,
-				testCase.args.issueTypeID, testCase.args.name, testCase.args.description, testCase.args.helpText)
+			gotResult, gotResponse, err := requestTypeService.Create(testCase.args.ctx, testCase.args.serviceDeskID,
+				testCase.args.payload)
 
 			if testCase.wantErr {
 

--- a/pkg/infra/models/sm_request_field_test.go
+++ b/pkg/infra/models/sm_request_field_test.go
@@ -1198,7 +1198,7 @@ func TestCreateCustomerRequestPayloadScheme_MergeFields(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := fieldsMocked.Date("duedate", time.Now()); err != nil {
+	if err := fieldsMocked.Date("duedate", time.Date(2020, 1, 2, 3, 4, 5, 0, time.UTC)); err != nil {
 		log.Fatal(err)
 	}
 
@@ -1211,7 +1211,7 @@ func TestCreateCustomerRequestPayloadScheme_MergeFields(t *testing.T) {
 			"components":         []map[string]interface{}{map[string]interface{}{"name": "Jira"}, map[string]interface{}{"name": "Intranet"}},
 			"customfield_320239": []map[string]interface{}{map[string]interface{}{"accountId": "account-id-sample"}},
 			"description":        "I need a new *mouse* for my Mac",
-			"duedate":            "2023-06-21",
+			"duedate":            "2020-01-02",
 			"labels":             []string{"label-00", "label-01"},
 			"priority":           map[string]interface{}{"value": "Major"},
 			"summary":            "Request JSD help via REST"},

--- a/pkg/infra/models/sm_request_field_test.go
+++ b/pkg/infra/models/sm_request_field_test.go
@@ -1,7 +1,9 @@
 package models
 
 import (
+	"fmt"
 	"github.com/stretchr/testify/assert"
+	"log"
 	"testing"
 	"time"
 )
@@ -9,7 +11,7 @@ import (
 func TestCustomerRequestFields_Attachments(t *testing.T) {
 
 	type fields struct {
-		Fields []map[string]interface{}
+		Fields map[string]interface{}
 	}
 	type args struct {
 		attachments []string
@@ -23,7 +25,7 @@ func TestCustomerRequestFields_Attachments(t *testing.T) {
 	}{
 		{
 			name:   "when the parameters are correct",
-			fields: fields{},
+			fields: fields{Fields: make(map[string]interface{})},
 			args: args{
 				attachments: []string{"uuid-sample"},
 			},
@@ -32,7 +34,7 @@ func TestCustomerRequestFields_Attachments(t *testing.T) {
 
 		{
 			name:   "when the attachments are not provided",
-			fields: fields{},
+			fields: fields{Fields: make(map[string]interface{})},
 			args: args{
 				attachments: nil,
 			},
@@ -66,7 +68,7 @@ func TestCustomerRequestFields_Attachments(t *testing.T) {
 func TestCustomerRequestFields_Labels(t *testing.T) {
 
 	type fields struct {
-		Fields []map[string]interface{}
+		Fields map[string]interface{}
 	}
 	type args struct {
 		labels []string
@@ -80,7 +82,7 @@ func TestCustomerRequestFields_Labels(t *testing.T) {
 	}{
 		{
 			name:   "when the parameters are correct",
-			fields: fields{},
+			fields: fields{Fields: make(map[string]interface{})},
 			args: args{
 				labels: []string{"label-sample"},
 			},
@@ -89,7 +91,7 @@ func TestCustomerRequestFields_Labels(t *testing.T) {
 
 		{
 			name:   "when the labels are not provided",
-			fields: fields{},
+			fields: fields{Fields: make(map[string]interface{})},
 			args: args{
 				labels: nil,
 			},
@@ -123,7 +125,7 @@ func TestCustomerRequestFields_Labels(t *testing.T) {
 func TestCustomerRequestFields_Components(t *testing.T) {
 
 	type fields struct {
-		Fields []map[string]interface{}
+		Fields map[string]interface{}
 	}
 	type args struct {
 		components []string
@@ -137,7 +139,7 @@ func TestCustomerRequestFields_Components(t *testing.T) {
 	}{
 		{
 			name:   "when the parameters are correct",
-			fields: fields{},
+			fields: fields{Fields: make(map[string]interface{})},
 			args: args{
 				components: []string{"component-sample"},
 			},
@@ -146,7 +148,7 @@ func TestCustomerRequestFields_Components(t *testing.T) {
 
 		{
 			name:   "when the components are not provided",
-			fields: fields{},
+			fields: fields{Fields: make(map[string]interface{})},
 			args: args{
 				components: nil,
 			},
@@ -180,7 +182,7 @@ func TestCustomerRequestFields_Components(t *testing.T) {
 func TestCustomerRequestFields_Groups(t *testing.T) {
 
 	type fields struct {
-		Fields []map[string]interface{}
+		Fields map[string]interface{}
 	}
 	type args struct {
 		customFieldID string
@@ -195,7 +197,7 @@ func TestCustomerRequestFields_Groups(t *testing.T) {
 	}{
 		{
 			name:   "when the parameters are correct",
-			fields: fields{},
+			fields: fields{Fields: make(map[string]interface{})},
 			args: args{
 				customFieldID: "customfield_10000",
 				groups:        []string{"group-sample"},
@@ -205,7 +207,7 @@ func TestCustomerRequestFields_Groups(t *testing.T) {
 
 		{
 			name:   "when the customfield is not provided",
-			fields: fields{},
+			fields: fields{Fields: make(map[string]interface{})},
 			args: args{
 				customFieldID: "",
 				groups:        []string{"group-sample"},
@@ -216,7 +218,7 @@ func TestCustomerRequestFields_Groups(t *testing.T) {
 
 		{
 			name:   "when the groups are not provided",
-			fields: fields{},
+			fields: fields{Fields: make(map[string]interface{})},
 			args: args{
 				customFieldID: "customfield_10000",
 				groups:        nil,
@@ -251,7 +253,7 @@ func TestCustomerRequestFields_Groups(t *testing.T) {
 func TestCustomerRequestFields_Group(t *testing.T) {
 
 	type fields struct {
-		Fields []map[string]interface{}
+		Fields map[string]interface{}
 	}
 	type args struct {
 		customFieldID string
@@ -266,7 +268,7 @@ func TestCustomerRequestFields_Group(t *testing.T) {
 	}{
 		{
 			name:   "when the parameters are correct",
-			fields: fields{},
+			fields: fields{Fields: make(map[string]interface{})},
 			args: args{
 				customFieldID: "customfield_10000",
 				group:         "group-sample",
@@ -276,7 +278,7 @@ func TestCustomerRequestFields_Group(t *testing.T) {
 
 		{
 			name:   "when the customfield is not provided",
-			fields: fields{},
+			fields: fields{Fields: make(map[string]interface{})},
 			args: args{
 				customFieldID: "",
 				group:         "group-sample",
@@ -287,7 +289,7 @@ func TestCustomerRequestFields_Group(t *testing.T) {
 
 		{
 			name:   "when the group is not provided",
-			fields: fields{},
+			fields: fields{Fields: make(map[string]interface{})},
 			args: args{
 				customFieldID: "customfield_10000",
 				group:         "",
@@ -322,7 +324,7 @@ func TestCustomerRequestFields_Group(t *testing.T) {
 func TestCustomerRequestFields_URL(t *testing.T) {
 
 	type fields struct {
-		Fields []map[string]interface{}
+		Fields map[string]interface{}
 	}
 	type args struct {
 		customFieldID string
@@ -337,7 +339,7 @@ func TestCustomerRequestFields_URL(t *testing.T) {
 	}{
 		{
 			name:   "when the parameters are correct",
-			fields: fields{},
+			fields: fields{Fields: make(map[string]interface{})},
 			args: args{
 				customFieldID: "customfield_10000",
 				url:           "url-sample",
@@ -347,7 +349,7 @@ func TestCustomerRequestFields_URL(t *testing.T) {
 
 		{
 			name:   "when the customfield is not provided",
-			fields: fields{},
+			fields: fields{Fields: make(map[string]interface{})},
 			args: args{
 				customFieldID: "",
 				url:           "url-sample",
@@ -358,7 +360,7 @@ func TestCustomerRequestFields_URL(t *testing.T) {
 
 		{
 			name:   "when the url is not provided",
-			fields: fields{},
+			fields: fields{Fields: make(map[string]interface{})},
 			args: args{
 				customFieldID: "customfield_10000",
 				url:           "",
@@ -393,7 +395,7 @@ func TestCustomerRequestFields_URL(t *testing.T) {
 func TestCustomerRequestFields_Text(t *testing.T) {
 
 	type fields struct {
-		Fields []map[string]interface{}
+		Fields map[string]interface{}
 	}
 	type args struct {
 		customFieldID string
@@ -408,7 +410,7 @@ func TestCustomerRequestFields_Text(t *testing.T) {
 	}{
 		{
 			name:   "when the parameters are correct",
-			fields: fields{},
+			fields: fields{Fields: make(map[string]interface{})},
 			args: args{
 				customFieldID: "customfield_10000",
 				textValue:     "text-sample",
@@ -418,7 +420,7 @@ func TestCustomerRequestFields_Text(t *testing.T) {
 
 		{
 			name:   "when the customfield is not provided",
-			fields: fields{},
+			fields: fields{Fields: make(map[string]interface{})},
 			args: args{
 				customFieldID: "",
 				textValue:     "url-sample",
@@ -429,7 +431,7 @@ func TestCustomerRequestFields_Text(t *testing.T) {
 
 		{
 			name:   "when the text is not provided",
-			fields: fields{},
+			fields: fields{Fields: make(map[string]interface{})},
 			args: args{
 				customFieldID: "customfield_10000",
 				textValue:     "",
@@ -464,7 +466,7 @@ func TestCustomerRequestFields_Text(t *testing.T) {
 func TestCustomerRequestFields_DateTime(t *testing.T) {
 
 	type fields struct {
-		Fields []map[string]interface{}
+		Fields map[string]interface{}
 	}
 	type args struct {
 		customFieldID string
@@ -479,7 +481,7 @@ func TestCustomerRequestFields_DateTime(t *testing.T) {
 	}{
 		{
 			name:   "when the parameters are correct",
-			fields: fields{},
+			fields: fields{Fields: make(map[string]interface{})},
 			args: args{
 				customFieldID: "customfield_10000",
 				dateValue:     time.Now().AddDate(0, -1, 0),
@@ -489,7 +491,7 @@ func TestCustomerRequestFields_DateTime(t *testing.T) {
 
 		{
 			name:   "when the customfield is not provided",
-			fields: fields{},
+			fields: fields{Fields: make(map[string]interface{})},
 			args: args{
 				customFieldID: "",
 				dateValue:     time.Now().AddDate(0, -1, 0),
@@ -500,7 +502,7 @@ func TestCustomerRequestFields_DateTime(t *testing.T) {
 
 		{
 			name:   "when the date-time is not provided",
-			fields: fields{},
+			fields: fields{Fields: make(map[string]interface{})},
 			args: args{
 				customFieldID: "customfield_10000",
 			},
@@ -534,7 +536,7 @@ func TestCustomerRequestFields_DateTime(t *testing.T) {
 func TestCustomerRequestFields_Date(t *testing.T) {
 
 	type fields struct {
-		Fields []map[string]interface{}
+		Fields map[string]interface{}
 	}
 	type args struct {
 		customFieldID string
@@ -549,7 +551,7 @@ func TestCustomerRequestFields_Date(t *testing.T) {
 	}{
 		{
 			name:   "when the parameters are correct",
-			fields: fields{},
+			fields: fields{Fields: make(map[string]interface{})},
 			args: args{
 				customFieldID: "customfield_10000",
 				dateValue:     time.Now().AddDate(0, -1, 0),
@@ -559,7 +561,7 @@ func TestCustomerRequestFields_Date(t *testing.T) {
 
 		{
 			name:   "when the customfield is not provided",
-			fields: fields{},
+			fields: fields{Fields: make(map[string]interface{})},
 			args: args{
 				customFieldID: "",
 				dateValue:     time.Now().AddDate(0, -1, 0),
@@ -570,7 +572,7 @@ func TestCustomerRequestFields_Date(t *testing.T) {
 
 		{
 			name:   "when the date-time is not provided",
-			fields: fields{},
+			fields: fields{Fields: make(map[string]interface{})},
 			args: args{
 				customFieldID: "customfield_10000",
 			},
@@ -604,7 +606,7 @@ func TestCustomerRequestFields_Date(t *testing.T) {
 func TestCustomerRequestFields_MultiSelect(t *testing.T) {
 
 	type fields struct {
-		Fields []map[string]interface{}
+		Fields map[string]interface{}
 	}
 	type args struct {
 		customFieldID string
@@ -619,7 +621,7 @@ func TestCustomerRequestFields_MultiSelect(t *testing.T) {
 	}{
 		{
 			name:   "when the parameters are correct",
-			fields: fields{},
+			fields: fields{Fields: make(map[string]interface{})},
 			args: args{
 				customFieldID: "customfield_10000",
 				options:       []string{"option-1"},
@@ -629,7 +631,7 @@ func TestCustomerRequestFields_MultiSelect(t *testing.T) {
 
 		{
 			name:   "when the customfield is not provided",
-			fields: fields{},
+			fields: fields{Fields: make(map[string]interface{})},
 			args: args{
 				customFieldID: "",
 				options:       []string{"option-1"},
@@ -640,7 +642,7 @@ func TestCustomerRequestFields_MultiSelect(t *testing.T) {
 
 		{
 			name:   "when the groups are not provided",
-			fields: fields{},
+			fields: fields{Fields: make(map[string]interface{})},
 			args: args{
 				customFieldID: "customfield_10000",
 				options:       nil,
@@ -675,7 +677,7 @@ func TestCustomerRequestFields_MultiSelect(t *testing.T) {
 func TestCustomerRequestFields_Select(t *testing.T) {
 
 	type fields struct {
-		Fields []map[string]interface{}
+		Fields map[string]interface{}
 	}
 	type args struct {
 		customFieldID string
@@ -690,7 +692,7 @@ func TestCustomerRequestFields_Select(t *testing.T) {
 	}{
 		{
 			name:   "when the parameters are correct",
-			fields: fields{},
+			fields: fields{Fields: make(map[string]interface{})},
 			args: args{
 				customFieldID: "customfield_10000",
 				option:        "option-sample",
@@ -700,7 +702,7 @@ func TestCustomerRequestFields_Select(t *testing.T) {
 
 		{
 			name:   "when the customfield is not provided",
-			fields: fields{},
+			fields: fields{Fields: make(map[string]interface{})},
 			args: args{
 				customFieldID: "",
 				option:        "option-sample",
@@ -711,7 +713,7 @@ func TestCustomerRequestFields_Select(t *testing.T) {
 
 		{
 			name:   "when the group is not provided",
-			fields: fields{},
+			fields: fields{Fields: make(map[string]interface{})},
 			args: args{
 				customFieldID: "customfield_10000",
 				option:        "",
@@ -746,7 +748,7 @@ func TestCustomerRequestFields_Select(t *testing.T) {
 func TestCustomerRequestFields_RadioButton(t *testing.T) {
 
 	type fields struct {
-		Fields []map[string]interface{}
+		Fields map[string]interface{}
 	}
 	type args struct {
 		customFieldID string
@@ -761,7 +763,7 @@ func TestCustomerRequestFields_RadioButton(t *testing.T) {
 	}{
 		{
 			name:   "when the parameters are correct",
-			fields: fields{},
+			fields: fields{Fields: make(map[string]interface{})},
 			args: args{
 				customFieldID: "customfield_10000",
 				option:        "option-sample",
@@ -771,7 +773,7 @@ func TestCustomerRequestFields_RadioButton(t *testing.T) {
 
 		{
 			name:   "when the customfield is not provided",
-			fields: fields{},
+			fields: fields{Fields: make(map[string]interface{})},
 			args: args{
 				customFieldID: "",
 				option:        "option-sample",
@@ -782,7 +784,7 @@ func TestCustomerRequestFields_RadioButton(t *testing.T) {
 
 		{
 			name:   "when the group is not provided",
-			fields: fields{},
+			fields: fields{Fields: make(map[string]interface{})},
 			args: args{
 				customFieldID: "customfield_10000",
 				option:        "",
@@ -817,7 +819,7 @@ func TestCustomerRequestFields_RadioButton(t *testing.T) {
 func TestCustomerRequestFields_User(t *testing.T) {
 
 	type fields struct {
-		Fields []map[string]interface{}
+		Fields map[string]interface{}
 	}
 	type args struct {
 		customFieldID string
@@ -832,7 +834,7 @@ func TestCustomerRequestFields_User(t *testing.T) {
 	}{
 		{
 			name:   "when the parameters are correct",
-			fields: fields{},
+			fields: fields{Fields: make(map[string]interface{})},
 			args: args{
 				customFieldID: "customfield_10000",
 				accountID:     "account-id-sample-uuid",
@@ -842,7 +844,7 @@ func TestCustomerRequestFields_User(t *testing.T) {
 
 		{
 			name:   "when the customfield is not provided",
-			fields: fields{},
+			fields: fields{Fields: make(map[string]interface{})},
 			args: args{
 				customFieldID: "",
 				accountID:     "account-id-sample-uuid",
@@ -853,7 +855,7 @@ func TestCustomerRequestFields_User(t *testing.T) {
 
 		{
 			name:   "when the group is not provided",
-			fields: fields{},
+			fields: fields{Fields: make(map[string]interface{})},
 			args: args{
 				customFieldID: "customfield_10000",
 				accountID:     "",
@@ -888,7 +890,7 @@ func TestCustomerRequestFields_User(t *testing.T) {
 func TestCustomerRequestFields_Users(t *testing.T) {
 
 	type fields struct {
-		Fields []map[string]interface{}
+		Fields map[string]interface{}
 	}
 	type args struct {
 		customFieldID string
@@ -903,7 +905,7 @@ func TestCustomerRequestFields_Users(t *testing.T) {
 	}{
 		{
 			name:   "when the parameters are correct",
-			fields: fields{},
+			fields: fields{Fields: make(map[string]interface{})},
 			args: args{
 				customFieldID: "customfield_10000",
 				accountIDs:    []string{"account-id-sample-uuid"},
@@ -913,7 +915,7 @@ func TestCustomerRequestFields_Users(t *testing.T) {
 
 		{
 			name:   "when the customfield is not provided",
-			fields: fields{},
+			fields: fields{Fields: make(map[string]interface{})},
 			args: args{
 				customFieldID: "",
 				accountIDs:    []string{"account-id-sample-uuid"},
@@ -924,7 +926,7 @@ func TestCustomerRequestFields_Users(t *testing.T) {
 
 		{
 			name:   "when the group is not provided",
-			fields: fields{},
+			fields: fields{Fields: make(map[string]interface{})},
 			args: args{
 				customFieldID: "customfield_10000",
 				accountIDs:    nil,
@@ -959,7 +961,7 @@ func TestCustomerRequestFields_Users(t *testing.T) {
 func TestCustomerRequestFields_Number(t *testing.T) {
 
 	type fields struct {
-		Fields []map[string]interface{}
+		Fields map[string]interface{}
 	}
 	type args struct {
 		customFieldID string
@@ -974,7 +976,7 @@ func TestCustomerRequestFields_Number(t *testing.T) {
 	}{
 		{
 			name:   "when the parameters are correct",
-			fields: fields{},
+			fields: fields{Fields: make(map[string]interface{})},
 			args: args{
 				customFieldID: "customfield_10000",
 				numberValue:   10000.232,
@@ -984,7 +986,7 @@ func TestCustomerRequestFields_Number(t *testing.T) {
 
 		{
 			name:   "when the customfield is not provided",
-			fields: fields{},
+			fields: fields{Fields: make(map[string]interface{})},
 			args: args{
 				customFieldID: "",
 				numberValue:   10000.232,
@@ -1019,7 +1021,7 @@ func TestCustomerRequestFields_Number(t *testing.T) {
 func TestCustomerRequestFields_CheckBox(t *testing.T) {
 
 	type fields struct {
-		Fields []map[string]interface{}
+		Fields map[string]interface{}
 	}
 	type args struct {
 		customFieldID string
@@ -1034,7 +1036,7 @@ func TestCustomerRequestFields_CheckBox(t *testing.T) {
 	}{
 		{
 			name:   "when the parameters are correct",
-			fields: fields{},
+			fields: fields{Fields: make(map[string]interface{})},
 			args: args{
 				customFieldID: "customfield_10000",
 				options:       []string{"option-1"},
@@ -1044,7 +1046,7 @@ func TestCustomerRequestFields_CheckBox(t *testing.T) {
 
 		{
 			name:   "when the customfield is not provided",
-			fields: fields{},
+			fields: fields{Fields: make(map[string]interface{})},
 			args: args{
 				customFieldID: "",
 				options:       []string{"option-1"},
@@ -1055,7 +1057,7 @@ func TestCustomerRequestFields_CheckBox(t *testing.T) {
 
 		{
 			name:   "when the groups are not provided",
-			fields: fields{},
+			fields: fields{Fields: make(map[string]interface{})},
 			args: args{
 				customFieldID: "customfield_10000",
 				options:       nil,
@@ -1089,7 +1091,7 @@ func TestCustomerRequestFields_CheckBox(t *testing.T) {
 
 func TestCustomerRequestFields_Cascading(t *testing.T) {
 	type fields struct {
-		Fields []map[string]interface{}
+		Fields map[string]interface{}
 	}
 	type args struct {
 		customFieldID string
@@ -1105,7 +1107,7 @@ func TestCustomerRequestFields_Cascading(t *testing.T) {
 	}{
 		{
 			name:   "when the parameters are correct",
-			fields: fields{},
+			fields: fields{Fields: make(map[string]interface{})},
 			args: args{
 				customFieldID: "customfield_10001",
 				parent:        "America",
@@ -1116,7 +1118,7 @@ func TestCustomerRequestFields_Cascading(t *testing.T) {
 
 		{
 			name:   "when the custom-field is not provided",
-			fields: fields{},
+			fields: fields{Fields: make(map[string]interface{})},
 			args: args{
 				customFieldID: "",
 				parent:        "America",
@@ -1128,7 +1130,7 @@ func TestCustomerRequestFields_Cascading(t *testing.T) {
 
 		{
 			name:   "when the parent value is not provided",
-			fields: fields{},
+			fields: fields{Fields: make(map[string]interface{})},
 			args: args{
 				customFieldID: "customfield_10001",
 				parent:        "",
@@ -1140,7 +1142,7 @@ func TestCustomerRequestFields_Cascading(t *testing.T) {
 
 		{
 			name:   "when the child value is not provided",
-			fields: fields{},
+			fields: fields{Fields: make(map[string]interface{})},
 			args: args{
 				customFieldID: "customfield_10001",
 				parent:        "America",
@@ -1168,6 +1170,131 @@ func TestCustomerRequestFields_Cascading(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 			}
+		})
+	}
+}
+
+func TestCreateCustomerRequestPayloadScheme_MergeFields(t *testing.T) {
+
+	fieldsMocked := &CustomerRequestFields{Fields: make(map[string]interface{})}
+
+	if err := fieldsMocked.Text("summary", "Request JSD help via REST"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := fieldsMocked.Text("description", "I need a new *mouse* for my Mac"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := fieldsMocked.Select("priority", "Major"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := fieldsMocked.Components([]string{"Jira", "Intranet"}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := fieldsMocked.Users("customfield_320239", []string{"account-id-sample"}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := fieldsMocked.Date("duedate", time.Now()); err != nil {
+		log.Fatal(err)
+	}
+
+	if err := fieldsMocked.Labels([]string{"label-00", "label-01"}); err != nil {
+		log.Fatal(err)
+	}
+
+	payloadMocked := map[string]interface{}{
+		"requestFieldValues": map[string]interface{}{
+			"components":         []map[string]interface{}{map[string]interface{}{"name": "Jira"}, map[string]interface{}{"name": "Intranet"}},
+			"customfield_320239": []map[string]interface{}{map[string]interface{}{"accountId": "account-id-sample"}},
+			"description":        "I need a new *mouse* for my Mac",
+			"duedate":            "2023-06-21",
+			"labels":             []string{"label-00", "label-01"},
+			"priority":           map[string]interface{}{"value": "Major"},
+			"summary":            "Request JSD help via REST"},
+		"requestParticipants": []interface{}{"uuid-sample-1", "uuid-sample-2"},
+		"requestTypeId":       "28881",
+		"serviceDeskId":       "29990"}
+
+	type fields struct {
+		RequestParticipants []string
+		ServiceDeskID       string
+		RequestTypeID       string
+	}
+	type args struct {
+		fields *CustomerRequestFields
+	}
+
+	testCases := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    map[string]interface{}
+		wantErr assert.ErrorAssertionFunc
+		Err     error
+	}{
+		{
+			name: "when the parameters are correct",
+			fields: fields{
+				RequestParticipants: []string{"uuid-sample-1", "uuid-sample-2"},
+				ServiceDeskID:       "29990",
+				RequestTypeID:       "28881",
+			},
+			args: args{
+				fields: fieldsMocked,
+			},
+			want:    payloadMocked,
+			wantErr: assert.NoError,
+		},
+
+		{
+			name: "when the field struct is not provided",
+			fields: fields{
+				RequestParticipants: []string{"uuid-sample-1", "uuid-sample-2"},
+				ServiceDeskID:       "29990",
+				RequestTypeID:       "28881",
+			},
+			args: args{
+				fields: nil,
+			},
+			wantErr: assert.Error,
+			Err:     ErrNoCustomFieldError,
+		},
+
+		{
+			name: "when the field struct does not contain values",
+			fields: fields{
+				RequestParticipants: []string{"uuid-sample-1", "uuid-sample-2"},
+				ServiceDeskID:       "29990",
+				RequestTypeID:       "28881",
+			},
+			args: args{
+				fields: &CustomerRequestFields{},
+			},
+			wantErr: assert.Error,
+			Err:     ErrNoCustomFieldError,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+
+			c := &CreateCustomerRequestPayloadScheme{
+				RequestParticipants: testCase.fields.RequestParticipants,
+				ServiceDeskID:       testCase.fields.ServiceDeskID,
+				RequestTypeID:       testCase.fields.RequestTypeID,
+			}
+
+			got, err := c.MergeFields(testCase.args.fields)
+
+			if !testCase.wantErr(t, err, fmt.Sprintf("MergeFields(%v)", testCase.args.fields)) {
+
+				assert.NoError(t, err)
+				return
+			}
+			assert.Equalf(t, testCase.want, got, "MergeFields(%v)", testCase.args.fields)
 		})
 	}
 }

--- a/pkg/infra/models/sm_request_type.go
+++ b/pkg/infra/models/sm_request_type.go
@@ -46,6 +46,13 @@ type RequestTypeScheme struct {
 	Expands       []string `json:"_expands,omitempty"`
 }
 
+type RequestTypePayloadScheme struct {
+	Description string `json:"description,omitempty"`
+	HelpText    string `json:"helpText,omitempty"`
+	IssueTypeId string `json:"issueTypeId,omitempty"`
+	Name        string `json:"name,omitempty"`
+}
+
 type RequestTypeFieldsScheme struct {
 	RequestTypeFields         []*RequestTypeFieldScheme `json:"requestTypeFields,omitempty"`
 	CanRaiseOnBehalfOf        bool                      `json:"canRaiseOnBehalfOf,omitempty"`

--- a/service/sm/type.go
+++ b/service/sm/type.go
@@ -27,7 +27,7 @@ type TypeConnector interface {
 	// POST /rest/servicedeskapi/servicedesk/{serviceDeskId}/requesttype
 	//
 	// https://docs.go-atlassian.io/jira-service-management-cloud/request/types#create-request-type
-	Create(ctx context.Context, serviceDeskID int, issueTypeID, name, description, helpText string) (*model.RequestTypeScheme, *model.ResponseScheme, error)
+	Create(ctx context.Context, serviceDeskID int, payload *model.RequestTypePayloadScheme) (*model.RequestTypeScheme, *model.ResponseScheme, error)
 
 	// Get returns a customer request type from a service desk.
 	//


### PR DESCRIPTION
- Changed the client interface from Client interface to Connector interface  on the service management module

- 🐞 The requestFieldValues object was overwritten map values on the CustomerRequestFields struct methods because the methods that appends fields on the slice of maps is replacing the information on the iteration.

- This was fixed replacing the Fields struct tag from the CustomerRequestFields (from []map[string]interface{} to map[string]interface{}).

- With that change, the Fields tag appends the information to avoid the overwriting them send the information to the consolidation method (*MergeFields*)

- Some logic was changed on the _MergeFields_ method, removing the _mergo_ iteration and replace it with the creation of the requestFieldValues map. 

- When the requestFieldValues map is created, it's merged with the request struct information.

- In conclusion, the custom fields are added dynamically and the customer request can be created with multiple form types :).