### PR TITLE
Fix Issue #240: Adjust SpaceSchemeV2 `id` & `homepageID` Types

### DIFF
--- a/confluence/internal/space_v2_impl_test.go
+++ b/confluence/internal/space_v2_impl_test.go
@@ -14,7 +14,7 @@ import (
 func Test_internalSpaceV2Impl_Bulk(t *testing.T) {
 
 	optionsMocked := &model.GetSpacesOptionSchemeV2{
-		IDs:               []int{10001, 10002},
+		IDs:               []string{"10001", "10002"},
 		Keys:              []string{"DUMMY"},
 		Type:              "global",
 		Status:            "current",

--- a/pkg/infra/models/confluence_space_v2.go
+++ b/pkg/infra/models/confluence_space_v2.go
@@ -28,7 +28,7 @@ type SpaceSchemeV2 struct {
 	Name        string                    `json:"name,omitempty"`
 	Type        string                    `json:"type,omitempty"`
 	Status      string                    `json:"status,omitempty"`
-	HomepageId  int                       `json:"homepageId,omitempty"`
+	HomepageId  string                    `json:"homepageId,omitempty"`
 	Description *SpaceDescriptionSchemeV2 `json:"description,omitempty"`
 }
 

--- a/pkg/infra/models/confluence_space_v2.go
+++ b/pkg/infra/models/confluence_space_v2.go
@@ -12,7 +12,7 @@ type SpacePageLinkSchemeV2 struct {
 }
 
 type GetSpacesOptionSchemeV2 struct {
-	IDs               []int
+	IDs               []string
 	Keys              []string
 	Type              string
 	Status            string
@@ -23,7 +23,7 @@ type GetSpacesOptionSchemeV2 struct {
 }
 
 type SpaceSchemeV2 struct {
-	ID          int                       `json:"id,omitempty"`
+	ID          string                    `json:"id,omitempty"`
 	Key         string                    `json:"key,omitempty"`
 	Name        string                    `json:"name,omitempty"`
 	Type        string                    `json:"type,omitempty"`


### PR DESCRIPTION
Fixes #240 by addressing the following two discrepancies between Confluence Space V2 API's Get Method return values and `SpaceSchemaV2`'s member types':
- Confluence Space V2 API Returns HomepageID As String
- Confluence Space V2 API Returns ID As String
