### PR TITLE
:boom: Improved the SM.Request.Create() method.

### DIFF
--- a/jira/sm/internal/request_impl.go
+++ b/jira/sm/internal/request_impl.go
@@ -64,8 +64,8 @@ type RequestService struct {
 // POST /rest/servicedeskapi/request
 //
 // https://docs.go-atlassian.io/jira-service-management/request#create-customer-request
-func (s *RequestService) Create(ctx context.Context, payload *model.CreateCustomerRequestPayloadScheme, fields *model.CustomerRequestFields) (*model.CustomerRequestScheme, *model.ResponseScheme, error) {
-	return s.internalClient.Create(ctx, payload, fields)
+func (s *RequestService) Create(ctx context.Context, payload *model.CreateCustomerRequestPayloadScheme) (*model.CustomerRequestScheme, *model.ResponseScheme, error) {
+	return s.internalClient.Create(ctx, payload)
 }
 
 // Gets returns all customer requests for the user executing the query.
@@ -131,20 +131,11 @@ type internalServiceRequestImpl struct {
 	version string
 }
 
-func (i *internalServiceRequestImpl) Create(ctx context.Context, payload *model.CreateCustomerRequestPayloadScheme, fields *model.CustomerRequestFields) (*model.CustomerRequestScheme, *model.ResponseScheme, error) {
-
-	if fields == nil || fields.Fields == nil {
-		return nil, nil, model.ErrNoCustomRequestFieldsError
-	}
-
-	payloadWithFields, err := payload.MergeFields(fields)
-	if err != nil {
-		return nil, nil, err
-	}
+func (i *internalServiceRequestImpl) Create(ctx context.Context, payload *model.CreateCustomerRequestPayloadScheme) (*model.CustomerRequestScheme, *model.ResponseScheme, error) {
 
 	endpoint := "rest/servicedeskapi/request"
 
-	req, err := i.c.NewRequest(ctx, http.MethodPost, endpoint, "", payloadWithFields)
+	req, err := i.c.NewRequest(ctx, http.MethodPost, endpoint, "", payload)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/infra/models/errors.go
+++ b/pkg/infra/models/errors.go
@@ -158,6 +158,7 @@ var (
 	ErrNoAttachmentIdsError                = errors.New("sm: no attachment id's set")
 	ErrNoLabelsError                       = errors.New("sm: no label names set")
 	ErrNoComponentsError                   = errors.New("sm: no components set")
+	ErrNCoComponentError                   = errors.New("sm: no component set")
 	ErrNoWorkspaceIDError                  = errors.New("assets: no workspace id set")
 	ErrNoAqlQueryError                     = errors.New("assets: no aql query id set")
 	ErrNoIconIDError                       = errors.New("assets: no icon id set")

--- a/pkg/infra/models/sm_request_field.go
+++ b/pkg/infra/models/sm_request_field.go
@@ -1,267 +1,96 @@
 package models
 
 import (
-	"encoding/json"
-	"github.com/imdario/mergo"
 	"time"
 )
 
 type CreateCustomerRequestPayloadScheme struct {
-	RequestParticipants []string `json:"requestParticipants,omitempty"`
-	ServiceDeskID       string   `json:"serviceDeskId,omitempty"`
-	RequestTypeID       string   `json:"requestTypeId,omitempty"`
+	Channel             string                                  `json:"channel,omitempty"`
+	Form                *CreateCustomerRequestFormPayloadScheme `json:"form,omitempty"`
+	IsAdfRequest        bool                                    `json:"isAdfRequest,omitempty"`
+	RaiseOnBehalfOf     string                                  `json:"raiseOnBehalfOf,omitempty"`
+	RequestFieldValues  map[string]interface{}                  `json:"requestFieldValues,omitempty"`
+	RequestParticipants []string                                `json:"requestParticipants,omitempty"`
+	RequestTypeID       string                                  `json:"requestTypeId,omitempty"`
+	ServiceDeskID       string                                  `json:"serviceDeskId,omitempty"`
 }
 
-func (c *CreateCustomerRequestPayloadScheme) MergeFields(fields *CustomerRequestFields) (map[string]interface{}, error) {
-
-	if fields == nil || len(fields.Fields) == 0 {
-		return nil, ErrNoCustomFieldError
-	}
-
-	//Convert the IssueScheme struct to map[string]interface{}
-	issueSchemeAsBytes, err := json.Marshal(c)
-	if err != nil {
-		return nil, err
-	}
-
-	issueSchemeAsMap := make(map[string]interface{})
-	if err := json.Unmarshal(issueSchemeAsBytes, &issueSchemeAsMap); err != nil {
-		return nil, err
-	}
-
-	// Create the requestFieldValues object with the custom fields
-	fieldsAsMap := make(map[string]interface{})
-	for key, value := range fields.Fields {
-		fieldsAsMap[key] = value
-	}
-
-	requestFieldValues := map[string]interface{}{"requestFieldValues": fieldsAsMap}
-
-	// Merge the requestFieldValues map struct with the service desk request struct information
-	if err := mergo.Merge(&issueSchemeAsMap, requestFieldValues, mergo.WithOverride); err != nil {
-		return nil, err
-	}
-
-	return issueSchemeAsMap, nil
+type CreateCustomerRequestFormPayloadScheme struct {
+	Answers interface{} `json:"answers,omitempty"`
 }
 
-type CustomerRequestFields struct{ Fields map[string]interface{} }
+func (c *CreateCustomerRequestPayloadScheme) AddCustomField(key string, value interface{}) error {
 
-func (c *CustomerRequestFields) Attachments(attachments []string) error {
-
-	if len(attachments) == 0 {
-		return ErrNoAttachmentIdsError
+	if c.RequestFieldValues == nil {
+		c.RequestFieldValues = make(map[string]interface{})
 	}
 
-	c.Fields["attachments"] = attachments
+	c.RequestFieldValues[key] = value
 	return nil
 }
 
-func (c *CustomerRequestFields) Labels(labels []string) error {
+func (c *CreateCustomerRequestPayloadScheme) DateTimeCustomField(id string, value time.Time) error {
 
-	if len(labels) == 0 {
-		return ErrNoLabelsError
-	}
-
-	c.Fields["labels"] = labels
-	return nil
-}
-
-func (c *CustomerRequestFields) Components(components []string) error {
-
-	if len(components) == 0 {
-		return ErrNoComponentsError
-	}
-
-	var componentNode []map[string]interface{}
-	for _, component := range components {
-
-		var groupNode = map[string]interface{}{}
-		groupNode["name"] = component
-
-		componentNode = append(componentNode, groupNode)
-	}
-
-	c.Fields["components"] = componentNode
-	return nil
-}
-
-func (c *CustomerRequestFields) Groups(customFieldID string, groups []string) error {
-
-	if len(customFieldID) == 0 {
+	if id == "" {
 		return ErrNoCustomFieldIDError
 	}
 
-	if len(groups) == 0 {
-		return ErrNoGroupsNameError
-	}
-
-	var groupsNode []map[string]interface{}
-	for _, group := range groups {
-
-		var groupNode = map[string]interface{}{}
-		groupNode["name"] = group
-
-		groupsNode = append(groupsNode, groupNode)
-	}
-
-	var fieldNode = map[string]interface{}{}
-	fieldNode[customFieldID] = groupsNode
-
-	c.Fields["components"] = fieldNode
-	return nil
-}
-
-func (c *CustomerRequestFields) Group(customFieldID, group string) error {
-
-	if len(customFieldID) == 0 {
-		return ErrNoCustomFieldIDError
-	}
-
-	if len(group) == 0 {
-		return ErrNoGroupNameError
-	}
-
-	var groupNode = map[string]interface{}{}
-	groupNode["name"] = group
-
-	c.Fields[customFieldID] = groupNode
-	return nil
-}
-
-func (c *CustomerRequestFields) URL(customFieldID, URL string) error {
-
-	if len(customFieldID) == 0 {
-		return ErrNoCustomFieldIDError
-	}
-
-	if len(URL) == 0 {
-		return ErrNoUrlTypeError
-	}
-
-	c.Fields[customFieldID] = URL
-	return nil
-}
-
-func (c *CustomerRequestFields) Text(customFieldID, textValue string) error {
-
-	if len(customFieldID) == 0 {
-		return ErrNoCustomFieldIDError
-	}
-
-	if len(textValue) == 0 {
-		return ErrNoTextTypeError
-	}
-
-	c.Fields[customFieldID] = textValue
-	return nil
-}
-
-func (c *CustomerRequestFields) DateTime(customFieldID string, dateValue time.Time) error {
-
-	if len(customFieldID) == 0 {
-		return ErrNoCustomFieldIDError
-	}
-
-	if dateValue.IsZero() {
+	if value.IsZero() {
 		return ErrNoDateTimeTypeError
 	}
 
-	c.Fields[customFieldID] = dateValue.Format(time.RFC3339)
-	return nil
+	return c.AddCustomField(id, value.Format(time.RFC3339))
 }
 
-func (c *CustomerRequestFields) Date(customFieldID string, dateTimeValue time.Time) error {
+func (c *CreateCustomerRequestPayloadScheme) DateCustomField(id string, value time.Time) error {
 
-	if len(customFieldID) == 0 {
+	if id == "" {
 		return ErrNoCustomFieldIDError
 	}
 
-	if dateTimeValue.IsZero() {
-		return ErrNoDateTypeError
+	if value.IsZero() {
+		return ErrNoDateTimeTypeError
 	}
 
-	c.Fields[customFieldID] = dateTimeValue.Format("2006-01-02")
-	return nil
+	return c.AddCustomField(id, value.Format("2006-01-02"))
 }
 
-func (c *CustomerRequestFields) MultiSelect(customFieldID string, options []string) error {
+func (c *CreateCustomerRequestPayloadScheme) MultiSelectOrCheckBoxCustomField(id string, values []string) error {
 
-	if len(customFieldID) == 0 {
+	if id == "" {
 		return ErrNoCustomFieldIDError
 	}
 
-	if len(options) == 0 {
+	if len(values) == 0 {
 		return ErrNoMultiSelectTypeError
 	}
 
-	var multiSelectOptions []map[string]interface{}
-	for _, group := range options {
-
-		var groupNode = map[string]interface{}{}
-		groupNode["value"] = group
-
-		multiSelectOptions = append(multiSelectOptions, groupNode)
+	var options []map[string]interface{}
+	for _, option := range values {
+		optionNode := make(map[string]interface{})
+		optionNode["value"] = option
+		options = append(options, optionNode)
 	}
 
-	c.Fields[customFieldID] = multiSelectOptions
-	return nil
+	return c.AddCustomField(id, options)
 }
 
-func (c *CustomerRequestFields) Select(customFieldID string, option string) error {
+func (c *CreateCustomerRequestPayloadScheme) UserCustomField(id, accountID string) error {
 
-	if len(customFieldID) == 0 {
+	if id == "" {
 		return ErrNoCustomFieldIDError
 	}
 
-	if len(option) == 0 {
-		return ErrNoSelectTypeError
-	}
-
-	var selectNode = map[string]interface{}{}
-	selectNode["value"] = option
-
-	c.Fields[customFieldID] = selectNode
-	return nil
-}
-
-func (c *CustomerRequestFields) RadioButton(customFieldID, button string) error {
-
-	if len(customFieldID) == 0 {
-		return ErrNoCustomFieldIDError
-	}
-
-	if len(button) == 0 {
-		return ErrNoButtonTypeError
-	}
-
-	var selectNode = map[string]interface{}{}
-	selectNode["value"] = button
-
-	c.Fields[customFieldID] = selectNode
-	return nil
-}
-
-func (c *CustomerRequestFields) User(customFieldID string, accountID string) error {
-
-	if len(customFieldID) == 0 {
-		return ErrNoCustomFieldIDError
-	}
-
-	if len(accountID) == 0 {
+	if accountID == "" {
 		return ErrNoUserTypeError
 	}
 
-	var userNode = map[string]interface{}{}
-	userNode["accountId"] = accountID
-
-	c.Fields[customFieldID] = userNode
-	return nil
+	return c.AddCustomField(id, map[string]interface{}{"accountId": accountID})
 }
 
-func (c *CustomerRequestFields) Users(customFieldID string, accountIDs []string) error {
+func (c *CreateCustomerRequestPayloadScheme) UsersCustomField(id string, accountIDs []string) error {
 
-	if len(customFieldID) == 0 {
+	if id == "" {
 		return ErrNoCustomFieldIDError
 	}
 
@@ -269,73 +98,101 @@ func (c *CustomerRequestFields) Users(customFieldID string, accountIDs []string)
 		return ErrNoMultiUserTypeError
 	}
 
-	var accountsNode []map[string]interface{}
+	var accounts []map[string]interface{}
 	for _, accountID := range accountIDs {
 
-		var groupNode = map[string]interface{}{}
-		groupNode["accountId"] = accountID
+		if accountID == "" {
+			return ErrNoUserTypeError
+		}
 
-		accountsNode = append(accountsNode, groupNode)
+		accounts = append(accounts, map[string]interface{}{"accountId": accountID})
 	}
 
-	c.Fields[customFieldID] = accountsNode
-	return nil
+	return c.AddCustomField(id, accounts)
 }
 
-func (c *CustomerRequestFields) Number(customFieldID string, numberValue float64) error {
+func (c *CreateCustomerRequestPayloadScheme) CascadingCustomField(id, parent, child string) error {
 
-	if len(customFieldID) == 0 {
+	if id == "" {
 		return ErrNoCustomFieldIDError
 	}
 
-	c.Fields[customFieldID] = numberValue
-	return nil
-}
-
-func (c *CustomerRequestFields) CheckBox(customFieldID string, options []string) error {
-
-	if len(customFieldID) == 0 {
-		return ErrNoCustomFieldIDError
-	}
-
-	if len(options) == 0 {
-		return ErrNoCheckBoxTypeError
-	}
-
-	var groupsNode []map[string]interface{}
-	for _, group := range options {
-
-		var groupNode = map[string]interface{}{}
-		groupNode["value"] = group
-
-		groupsNode = append(groupsNode, groupNode)
-	}
-
-	c.Fields[customFieldID] = groupsNode
-	return nil
-}
-
-func (c *CustomerRequestFields) Cascading(customFieldID, parent, child string) error {
-
-	if len(customFieldID) == 0 {
-		return ErrNoCustomFieldIDError
-	}
-
-	if len(parent) == 0 {
+	if parent == "" {
 		return ErrNoCascadingParentError
 	}
 
-	if len(child) == 0 {
+	if child == "" {
 		return ErrNoCascadingChildError
 	}
 
-	var childNode = map[string]interface{}{}
-	childNode["value"] = child
+	childNode := map[string]interface{}{"value": child}
+	return c.AddCustomField(id, map[string]interface{}{"value": parent, "child": childNode})
+}
 
-	var parentNode = map[string]interface{}{}
-	parentNode["value"] = parent
-	parentNode["child"] = childNode
+func (c *CreateCustomerRequestPayloadScheme) GroupsCustomField(id string, names []string) error {
 
-	c.Fields[customFieldID] = parentNode
-	return nil
+	if id == "" {
+		return ErrNoCustomFieldIDError
+	}
+
+	if len(names) == 0 {
+		return ErrNoGroupsNameError
+	}
+
+	var groups []map[string]interface{}
+	for _, name := range names {
+
+		if name == "" {
+			return ErrNoGroupNameError
+		}
+
+		groups = append(groups, map[string]interface{}{"name": name})
+	}
+
+	return c.AddCustomField(id, groups)
+}
+
+func (c *CreateCustomerRequestPayloadScheme) GroupCustomField(id, name string) error {
+
+	if id == "" {
+		return ErrNoCustomFieldIDError
+	}
+
+	if name == "" {
+		return ErrNoGroupNameError
+	}
+
+	return c.AddCustomField(id, map[string]interface{}{"name": name})
+}
+
+func (c *CreateCustomerRequestPayloadScheme) RadioButtonOrSelectCustomField(id string, option string) error {
+
+	if id == "" {
+		return ErrNoCustomFieldIDError
+	}
+
+	if option == "" {
+		return ErrNoSelectTypeError
+	}
+
+	return c.AddCustomField(id, map[string]interface{}{"value": option})
+}
+
+func (c *CreateCustomerRequestPayloadScheme) Components(components []string) error {
+
+	if len(components) == 0 {
+		return ErrNoComponentsError
+	}
+
+	var values []map[string]interface{}
+	for _, component := range components {
+
+		if component == "" {
+			return ErrNCoComponentError
+		}
+
+		values = append(values, map[string]interface{}{"name": component})
+	}
+
+	return c.AddCustomField("components", values)
 }

--- a/pkg/infra/models/sm_request_field_test.go
+++ b/pkg/infra/models/sm_request_field_test.go
@@ -1,1128 +1,515 @@
 package models
 
 import (
-	"fmt"
 	"github.com/stretchr/testify/assert"
-	"log"
 	"testing"
 	"time"
 )
 
-func TestCustomerRequestFields_Attachments(t *testing.T) {
+func TestCreateCustomerRequestPayloadScheme_DateTimeCustomField(t *testing.T) {
 
 	type fields struct {
-		Fields map[string]interface{}
+		Channel             string
+		Form                *CreateCustomerRequestFormPayloadScheme
+		IsAdfRequest        bool
+		RaiseOnBehalfOf     string
+		RequestFieldValues  map[string]interface{}
+		RequestParticipants []string
+		RequestTypeID       string
+		ServiceDeskID       string
 	}
+
 	type args struct {
-		attachments []string
+		id    string
+		value time.Time
 	}
-	testCases := []struct {
-		name    string
-		fields  fields
-		args    args
-		wantErr bool
-		err     error
-	}{
-		{
-			name:   "when the parameters are correct",
-			fields: fields{Fields: make(map[string]interface{})},
-			args: args{
-				attachments: []string{"uuid-sample"},
-			},
-			wantErr: false,
-		},
 
-		{
-			name:   "when the attachments are not provided",
-			fields: fields{Fields: make(map[string]interface{})},
-			args: args{
-				attachments: nil,
-			},
-			wantErr: true,
-			err:     ErrNoAttachmentIdsError,
-		},
-	}
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-			c := &CustomerRequestFields{
-				Fields: testCase.fields.Fields,
-			}
-
-			err := c.Attachments(testCase.args.attachments)
-
-			if testCase.wantErr {
-
-				if err != nil {
-					t.Logf("error returned: %v", err.Error())
-				}
-				assert.EqualError(t, err, testCase.err.Error())
-
-			} else {
-				assert.NoError(t, err)
-			}
-
-		})
-	}
-}
-
-func TestCustomerRequestFields_Labels(t *testing.T) {
-
-	type fields struct {
-		Fields map[string]interface{}
-	}
-	type args struct {
-		labels []string
-	}
-	testCases := []struct {
-		name    string
-		fields  fields
-		args    args
-		wantErr bool
-		err     error
-	}{
-		{
-			name:   "when the parameters are correct",
-			fields: fields{Fields: make(map[string]interface{})},
-			args: args{
-				labels: []string{"label-sample"},
-			},
-			wantErr: false,
-		},
-
-		{
-			name:   "when the labels are not provided",
-			fields: fields{Fields: make(map[string]interface{})},
-			args: args{
-				labels: nil,
-			},
-			wantErr: true,
-			err:     ErrNoLabelsError,
-		},
-	}
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-			c := &CustomerRequestFields{
-				Fields: testCase.fields.Fields,
-			}
-
-			err := c.Labels(testCase.args.labels)
-
-			if testCase.wantErr {
-
-				if err != nil {
-					t.Logf("error returned: %v", err.Error())
-				}
-				assert.EqualError(t, err, testCase.err.Error())
-
-			} else {
-				assert.NoError(t, err)
-			}
-
-		})
-	}
-}
-
-func TestCustomerRequestFields_Components(t *testing.T) {
-
-	type fields struct {
-		Fields map[string]interface{}
-	}
-	type args struct {
-		components []string
-	}
-	testCases := []struct {
-		name    string
-		fields  fields
-		args    args
-		wantErr bool
-		err     error
-	}{
-		{
-			name:   "when the parameters are correct",
-			fields: fields{Fields: make(map[string]interface{})},
-			args: args{
-				components: []string{"component-sample"},
-			},
-			wantErr: false,
-		},
-
-		{
-			name:   "when the components are not provided",
-			fields: fields{Fields: make(map[string]interface{})},
-			args: args{
-				components: nil,
-			},
-			wantErr: true,
-			err:     ErrNoComponentsError,
-		},
-	}
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-			c := &CustomerRequestFields{
-				Fields: testCase.fields.Fields,
-			}
-
-			err := c.Components(testCase.args.components)
-
-			if testCase.wantErr {
-
-				if err != nil {
-					t.Logf("error returned: %v", err.Error())
-				}
-				assert.EqualError(t, err, testCase.err.Error())
-
-			} else {
-				assert.NoError(t, err)
-			}
-
-		})
-	}
-}
-
-func TestCustomerRequestFields_Groups(t *testing.T) {
-
-	type fields struct {
-		Fields map[string]interface{}
-	}
-	type args struct {
-		customFieldID string
-		groups        []string
-	}
-	testCases := []struct {
-		name    string
-		fields  fields
-		args    args
-		wantErr bool
-		err     error
-	}{
-		{
-			name:   "when the parameters are correct",
-			fields: fields{Fields: make(map[string]interface{})},
-			args: args{
-				customFieldID: "customfield_10000",
-				groups:        []string{"group-sample"},
-			},
-			wantErr: false,
-		},
-
-		{
-			name:   "when the customfield is not provided",
-			fields: fields{Fields: make(map[string]interface{})},
-			args: args{
-				customFieldID: "",
-				groups:        []string{"group-sample"},
-			},
-			wantErr: true,
-			err:     ErrNoCustomFieldIDError,
-		},
-
-		{
-			name:   "when the groups are not provided",
-			fields: fields{Fields: make(map[string]interface{})},
-			args: args{
-				customFieldID: "customfield_10000",
-				groups:        nil,
-			},
-			wantErr: true,
-			err:     ErrNoGroupsNameError,
-		},
-	}
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-			c := &CustomerRequestFields{
-				Fields: testCase.fields.Fields,
-			}
-
-			err := c.Groups(testCase.args.customFieldID, testCase.args.groups)
-
-			if testCase.wantErr {
-
-				if err != nil {
-					t.Logf("error returned: %v", err.Error())
-				}
-				assert.EqualError(t, err, testCase.err.Error())
-
-			} else {
-				assert.NoError(t, err)
-			}
-
-		})
-	}
-}
-
-func TestCustomerRequestFields_Group(t *testing.T) {
-
-	type fields struct {
-		Fields map[string]interface{}
-	}
-	type args struct {
-		customFieldID string
-		group         string
-	}
-	testCases := []struct {
-		name    string
-		fields  fields
-		args    args
-		wantErr bool
-		err     error
-	}{
-		{
-			name:   "when the parameters are correct",
-			fields: fields{Fields: make(map[string]interface{})},
-			args: args{
-				customFieldID: "customfield_10000",
-				group:         "group-sample",
-			},
-			wantErr: false,
-		},
-
-		{
-			name:   "when the customfield is not provided",
-			fields: fields{Fields: make(map[string]interface{})},
-			args: args{
-				customFieldID: "",
-				group:         "group-sample",
-			},
-			wantErr: true,
-			err:     ErrNoCustomFieldIDError,
-		},
-
-		{
-			name:   "when the group is not provided",
-			fields: fields{Fields: make(map[string]interface{})},
-			args: args{
-				customFieldID: "customfield_10000",
-				group:         "",
-			},
-			wantErr: true,
-			err:     ErrNoGroupNameError,
-		},
-	}
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-			c := &CustomerRequestFields{
-				Fields: testCase.fields.Fields,
-			}
-
-			err := c.Group(testCase.args.customFieldID, testCase.args.group)
-
-			if testCase.wantErr {
-
-				if err != nil {
-					t.Logf("error returned: %v", err.Error())
-				}
-				assert.EqualError(t, err, testCase.err.Error())
-
-			} else {
-				assert.NoError(t, err)
-			}
-
-		})
-	}
-}
-
-func TestCustomerRequestFields_URL(t *testing.T) {
-
-	type fields struct {
-		Fields map[string]interface{}
-	}
-	type args struct {
-		customFieldID string
-		url           string
-	}
-	testCases := []struct {
-		name    string
-		fields  fields
-		args    args
-		wantErr bool
-		err     error
-	}{
-		{
-			name:   "when the parameters are correct",
-			fields: fields{Fields: make(map[string]interface{})},
-			args: args{
-				customFieldID: "customfield_10000",
-				url:           "url-sample",
-			},
-			wantErr: false,
-		},
-
-		{
-			name:   "when the customfield is not provided",
-			fields: fields{Fields: make(map[string]interface{})},
-			args: args{
-				customFieldID: "",
-				url:           "url-sample",
-			},
-			wantErr: true,
-			err:     ErrNoCustomFieldIDError,
-		},
-
-		{
-			name:   "when the url is not provided",
-			fields: fields{Fields: make(map[string]interface{})},
-			args: args{
-				customFieldID: "customfield_10000",
-				url:           "",
-			},
-			wantErr: true,
-			err:     ErrNoUrlTypeError,
-		},
-	}
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-			c := &CustomerRequestFields{
-				Fields: testCase.fields.Fields,
-			}
-
-			err := c.URL(testCase.args.customFieldID, testCase.args.url)
-
-			if testCase.wantErr {
-
-				if err != nil {
-					t.Logf("error returned: %v", err.Error())
-				}
-				assert.EqualError(t, err, testCase.err.Error())
-
-			} else {
-				assert.NoError(t, err)
-			}
-
-		})
-	}
-}
-
-func TestCustomerRequestFields_Text(t *testing.T) {
-
-	type fields struct {
-		Fields map[string]interface{}
-	}
-	type args struct {
-		customFieldID string
-		textValue     string
-	}
-	testCases := []struct {
-		name    string
-		fields  fields
-		args    args
-		wantErr bool
-		err     error
-	}{
-		{
-			name:   "when the parameters are correct",
-			fields: fields{Fields: make(map[string]interface{})},
-			args: args{
-				customFieldID: "customfield_10000",
-				textValue:     "text-sample",
-			},
-			wantErr: false,
-		},
-
-		{
-			name:   "when the customfield is not provided",
-			fields: fields{Fields: make(map[string]interface{})},
-			args: args{
-				customFieldID: "",
-				textValue:     "url-sample",
-			},
-			wantErr: true,
-			err:     ErrNoCustomFieldIDError,
-		},
-
-		{
-			name:   "when the text is not provided",
-			fields: fields{Fields: make(map[string]interface{})},
-			args: args{
-				customFieldID: "customfield_10000",
-				textValue:     "",
-			},
-			wantErr: true,
-			err:     ErrNoTextTypeError,
-		},
-	}
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-			c := &CustomerRequestFields{
-				Fields: testCase.fields.Fields,
-			}
-
-			err := c.Text(testCase.args.customFieldID, testCase.args.textValue)
-
-			if testCase.wantErr {
-
-				if err != nil {
-					t.Logf("error returned: %v", err.Error())
-				}
-				assert.EqualError(t, err, testCase.err.Error())
-
-			} else {
-				assert.NoError(t, err)
-			}
-
-		})
-	}
-}
-
-func TestCustomerRequestFields_DateTime(t *testing.T) {
-
-	type fields struct {
-		Fields map[string]interface{}
-	}
-	type args struct {
-		customFieldID string
-		dateValue     time.Time
-	}
-	testCases := []struct {
-		name    string
-		fields  fields
-		args    args
-		wantErr bool
-		err     error
-	}{
-		{
-			name:   "when the parameters are correct",
-			fields: fields{Fields: make(map[string]interface{})},
-			args: args{
-				customFieldID: "customfield_10000",
-				dateValue:     time.Now().AddDate(0, -1, 0),
-			},
-			wantErr: false,
-		},
-
-		{
-			name:   "when the customfield is not provided",
-			fields: fields{Fields: make(map[string]interface{})},
-			args: args{
-				customFieldID: "",
-				dateValue:     time.Now().AddDate(0, -1, 0),
-			},
-			wantErr: true,
-			err:     ErrNoCustomFieldIDError,
-		},
-
-		{
-			name:   "when the date-time is not provided",
-			fields: fields{Fields: make(map[string]interface{})},
-			args: args{
-				customFieldID: "customfield_10000",
-			},
-			wantErr: true,
-			err:     ErrNoDateTimeTypeError,
-		},
-	}
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-			c := &CustomerRequestFields{
-				Fields: testCase.fields.Fields,
-			}
-
-			err := c.DateTime(testCase.args.customFieldID, testCase.args.dateValue)
-
-			if testCase.wantErr {
-
-				if err != nil {
-					t.Logf("error returned: %v", err.Error())
-				}
-				assert.EqualError(t, err, testCase.err.Error())
-
-			} else {
-				assert.NoError(t, err)
-			}
-
-		})
-	}
-}
-
-func TestCustomerRequestFields_Date(t *testing.T) {
-
-	type fields struct {
-		Fields map[string]interface{}
-	}
-	type args struct {
-		customFieldID string
-		dateValue     time.Time
-	}
-	testCases := []struct {
-		name    string
-		fields  fields
-		args    args
-		wantErr bool
-		err     error
-	}{
-		{
-			name:   "when the parameters are correct",
-			fields: fields{Fields: make(map[string]interface{})},
-			args: args{
-				customFieldID: "customfield_10000",
-				dateValue:     time.Now().AddDate(0, -1, 0),
-			},
-			wantErr: false,
-		},
-
-		{
-			name:   "when the customfield is not provided",
-			fields: fields{Fields: make(map[string]interface{})},
-			args: args{
-				customFieldID: "",
-				dateValue:     time.Now().AddDate(0, -1, 0),
-			},
-			wantErr: true,
-			err:     ErrNoCustomFieldIDError,
-		},
-
-		{
-			name:   "when the date-time is not provided",
-			fields: fields{Fields: make(map[string]interface{})},
-			args: args{
-				customFieldID: "customfield_10000",
-			},
-			wantErr: true,
-			err:     ErrNoDateTypeError,
-		},
-	}
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-			c := &CustomerRequestFields{
-				Fields: testCase.fields.Fields,
-			}
-
-			err := c.Date(testCase.args.customFieldID, testCase.args.dateValue)
-
-			if testCase.wantErr {
-
-				if err != nil {
-					t.Logf("error returned: %v", err.Error())
-				}
-				assert.EqualError(t, err, testCase.err.Error())
-
-			} else {
-				assert.NoError(t, err)
-			}
-
-		})
-	}
-}
-
-func TestCustomerRequestFields_MultiSelect(t *testing.T) {
-
-	type fields struct {
-		Fields map[string]interface{}
-	}
-	type args struct {
-		customFieldID string
-		options       []string
-	}
-	testCases := []struct {
-		name    string
-		fields  fields
-		args    args
-		wantErr bool
-		err     error
-	}{
-		{
-			name:   "when the parameters are correct",
-			fields: fields{Fields: make(map[string]interface{})},
-			args: args{
-				customFieldID: "customfield_10000",
-				options:       []string{"option-1"},
-			},
-			wantErr: false,
-		},
-
-		{
-			name:   "when the customfield is not provided",
-			fields: fields{Fields: make(map[string]interface{})},
-			args: args{
-				customFieldID: "",
-				options:       []string{"option-1"},
-			},
-			wantErr: true,
-			err:     ErrNoCustomFieldIDError,
-		},
-
-		{
-			name:   "when the groups are not provided",
-			fields: fields{Fields: make(map[string]interface{})},
-			args: args{
-				customFieldID: "customfield_10000",
-				options:       nil,
-			},
-			wantErr: true,
-			err:     ErrNoMultiSelectTypeError,
-		},
-	}
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-			c := &CustomerRequestFields{
-				Fields: testCase.fields.Fields,
-			}
-
-			err := c.MultiSelect(testCase.args.customFieldID, testCase.args.options)
-
-			if testCase.wantErr {
-
-				if err != nil {
-					t.Logf("error returned: %v", err.Error())
-				}
-				assert.EqualError(t, err, testCase.err.Error())
-
-			} else {
-				assert.NoError(t, err)
-			}
-
-		})
-	}
-}
-
-func TestCustomerRequestFields_Select(t *testing.T) {
-
-	type fields struct {
-		Fields map[string]interface{}
-	}
-	type args struct {
-		customFieldID string
-		option        string
-	}
-	testCases := []struct {
-		name    string
-		fields  fields
-		args    args
-		wantErr bool
-		err     error
-	}{
-		{
-			name:   "when the parameters are correct",
-			fields: fields{Fields: make(map[string]interface{})},
-			args: args{
-				customFieldID: "customfield_10000",
-				option:        "option-sample",
-			},
-			wantErr: false,
-		},
-
-		{
-			name:   "when the customfield is not provided",
-			fields: fields{Fields: make(map[string]interface{})},
-			args: args{
-				customFieldID: "",
-				option:        "option-sample",
-			},
-			wantErr: true,
-			err:     ErrNoCustomFieldIDError,
-		},
-
-		{
-			name:   "when the group is not provided",
-			fields: fields{Fields: make(map[string]interface{})},
-			args: args{
-				customFieldID: "customfield_10000",
-				option:        "",
-			},
-			wantErr: true,
-			err:     ErrNoSelectTypeError,
-		},
-	}
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-			c := &CustomerRequestFields{
-				Fields: testCase.fields.Fields,
-			}
-
-			err := c.Select(testCase.args.customFieldID, testCase.args.option)
-
-			if testCase.wantErr {
-
-				if err != nil {
-					t.Logf("error returned: %v", err.Error())
-				}
-				assert.EqualError(t, err, testCase.err.Error())
-
-			} else {
-				assert.NoError(t, err)
-			}
-
-		})
-	}
-}
-
-func TestCustomerRequestFields_RadioButton(t *testing.T) {
-
-	type fields struct {
-		Fields map[string]interface{}
-	}
-	type args struct {
-		customFieldID string
-		option        string
-	}
-	testCases := []struct {
-		name    string
-		fields  fields
-		args    args
-		wantErr bool
-		err     error
-	}{
-		{
-			name:   "when the parameters are correct",
-			fields: fields{Fields: make(map[string]interface{})},
-			args: args{
-				customFieldID: "customfield_10000",
-				option:        "option-sample",
-			},
-			wantErr: false,
-		},
-
-		{
-			name:   "when the customfield is not provided",
-			fields: fields{Fields: make(map[string]interface{})},
-			args: args{
-				customFieldID: "",
-				option:        "option-sample",
-			},
-			wantErr: true,
-			err:     ErrNoCustomFieldIDError,
-		},
-
-		{
-			name:   "when the group is not provided",
-			fields: fields{Fields: make(map[string]interface{})},
-			args: args{
-				customFieldID: "customfield_10000",
-				option:        "",
-			},
-			wantErr: true,
-			err:     ErrNoButtonTypeError,
-		},
-	}
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-			c := &CustomerRequestFields{
-				Fields: testCase.fields.Fields,
-			}
-
-			err := c.RadioButton(testCase.args.customFieldID, testCase.args.option)
-
-			if testCase.wantErr {
-
-				if err != nil {
-					t.Logf("error returned: %v", err.Error())
-				}
-				assert.EqualError(t, err, testCase.err.Error())
-
-			} else {
-				assert.NoError(t, err)
-			}
-
-		})
-	}
-}
-
-func TestCustomerRequestFields_User(t *testing.T) {
-
-	type fields struct {
-		Fields map[string]interface{}
-	}
-	type args struct {
-		customFieldID string
-		accountID     string
-	}
-	testCases := []struct {
-		name    string
-		fields  fields
-		args    args
-		wantErr bool
-		err     error
-	}{
-		{
-			name:   "when the parameters are correct",
-			fields: fields{Fields: make(map[string]interface{})},
-			args: args{
-				customFieldID: "customfield_10000",
-				accountID:     "account-id-sample-uuid",
-			},
-			wantErr: false,
-		},
-
-		{
-			name:   "when the customfield is not provided",
-			fields: fields{Fields: make(map[string]interface{})},
-			args: args{
-				customFieldID: "",
-				accountID:     "account-id-sample-uuid",
-			},
-			wantErr: true,
-			err:     ErrNoCustomFieldIDError,
-		},
-
-		{
-			name:   "when the group is not provided",
-			fields: fields{Fields: make(map[string]interface{})},
-			args: args{
-				customFieldID: "customfield_10000",
-				accountID:     "",
-			},
-			wantErr: true,
-			err:     ErrNoUserTypeError,
-		},
-	}
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-			c := &CustomerRequestFields{
-				Fields: testCase.fields.Fields,
-			}
-
-			err := c.User(testCase.args.customFieldID, testCase.args.accountID)
-
-			if testCase.wantErr {
-
-				if err != nil {
-					t.Logf("error returned: %v", err.Error())
-				}
-				assert.EqualError(t, err, testCase.err.Error())
-
-			} else {
-				assert.NoError(t, err)
-			}
-
-		})
-	}
-}
-
-func TestCustomerRequestFields_Users(t *testing.T) {
-
-	type fields struct {
-		Fields map[string]interface{}
-	}
-	type args struct {
-		customFieldID string
-		accountIDs    []string
-	}
-	testCases := []struct {
-		name    string
-		fields  fields
-		args    args
-		wantErr bool
-		err     error
-	}{
-		{
-			name:   "when the parameters are correct",
-			fields: fields{Fields: make(map[string]interface{})},
-			args: args{
-				customFieldID: "customfield_10000",
-				accountIDs:    []string{"account-id-sample-uuid"},
-			},
-			wantErr: false,
-		},
-
-		{
-			name:   "when the customfield is not provided",
-			fields: fields{Fields: make(map[string]interface{})},
-			args: args{
-				customFieldID: "",
-				accountIDs:    []string{"account-id-sample-uuid"},
-			},
-			wantErr: true,
-			err:     ErrNoCustomFieldIDError,
-		},
-
-		{
-			name:   "when the group is not provided",
-			fields: fields{Fields: make(map[string]interface{})},
-			args: args{
-				customFieldID: "customfield_10000",
-				accountIDs:    nil,
-			},
-			wantErr: true,
-			err:     ErrNoMultiUserTypeError,
-		},
-	}
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-			c := &CustomerRequestFields{
-				Fields: testCase.fields.Fields,
-			}
-
-			err := c.Users(testCase.args.customFieldID, testCase.args.accountIDs)
-
-			if testCase.wantErr {
-
-				if err != nil {
-					t.Logf("error returned: %v", err.Error())
-				}
-				assert.EqualError(t, err, testCase.err.Error())
-
-			} else {
-				assert.NoError(t, err)
-			}
-
-		})
-	}
-}
-
-func TestCustomerRequestFields_Number(t *testing.T) {
-
-	type fields struct {
-		Fields map[string]interface{}
-	}
-	type args struct {
-		customFieldID string
-		numberValue   float64
-	}
-	testCases := []struct {
-		name    string
-		fields  fields
-		args    args
-		wantErr bool
-		err     error
-	}{
-		{
-			name:   "when the parameters are correct",
-			fields: fields{Fields: make(map[string]interface{})},
-			args: args{
-				customFieldID: "customfield_10000",
-				numberValue:   10000.232,
-			},
-			wantErr: false,
-		},
-
-		{
-			name:   "when the customfield is not provided",
-			fields: fields{Fields: make(map[string]interface{})},
-			args: args{
-				customFieldID: "",
-				numberValue:   10000.232,
-			},
-			wantErr: true,
-			err:     ErrNoCustomFieldIDError,
-		},
-	}
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-			c := &CustomerRequestFields{
-				Fields: testCase.fields.Fields,
-			}
-
-			err := c.Number(testCase.args.customFieldID, testCase.args.numberValue)
-
-			if testCase.wantErr {
-
-				if err != nil {
-					t.Logf("error returned: %v", err.Error())
-				}
-				assert.EqualError(t, err, testCase.err.Error())
-
-			} else {
-				assert.NoError(t, err)
-			}
-
-		})
-	}
-}
-
-func TestCustomerRequestFields_CheckBox(t *testing.T) {
-
-	type fields struct {
-		Fields map[string]interface{}
-	}
-	type args struct {
-		customFieldID string
-		options       []string
-	}
-	testCases := []struct {
-		name    string
-		fields  fields
-		args    args
-		wantErr bool
-		err     error
-	}{
-		{
-			name:   "when the parameters are correct",
-			fields: fields{Fields: make(map[string]interface{})},
-			args: args{
-				customFieldID: "customfield_10000",
-				options:       []string{"option-1"},
-			},
-			wantErr: false,
-		},
-
-		{
-			name:   "when the customfield is not provided",
-			fields: fields{Fields: make(map[string]interface{})},
-			args: args{
-				customFieldID: "",
-				options:       []string{"option-1"},
-			},
-			wantErr: true,
-			err:     ErrNoCustomFieldIDError,
-		},
-
-		{
-			name:   "when the groups are not provided",
-			fields: fields{Fields: make(map[string]interface{})},
-			args: args{
-				customFieldID: "customfield_10000",
-				options:       nil,
-			},
-			wantErr: true,
-			err:     ErrNoCheckBoxTypeError,
-		},
-	}
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-			c := &CustomerRequestFields{
-				Fields: testCase.fields.Fields,
-			}
-
-			err := c.CheckBox(testCase.args.customFieldID, testCase.args.options)
-
-			if testCase.wantErr {
-
-				if err != nil {
-					t.Logf("error returned: %v", err.Error())
-				}
-				assert.EqualError(t, err, testCase.err.Error())
-
-			} else {
-				assert.NoError(t, err)
-			}
-
-		})
-	}
-}
-
-func TestCustomerRequestFields_Cascading(t *testing.T) {
-	type fields struct {
-		Fields map[string]interface{}
-	}
-	type args struct {
-		customFieldID string
-		parent        string
-		child         string
-	}
-	testCases := []struct {
+	tests := []struct {
 		name    string
 		fields  fields
 		args    args
 		wantErr bool
 		Err     error
+		want    *CreateCustomerRequestPayloadScheme
 	}{
 		{
 			name:   "when the parameters are correct",
-			fields: fields{Fields: make(map[string]interface{})},
+			fields: fields{},
 			args: args{
-				customFieldID: "customfield_10001",
-				parent:        "America",
-				child:         "US",
+				id:    "customfield_10021",
+				value: time.Date(2019, 1, 1, 0, 0, 0, 0, time.UTC),
 			},
 			wantErr: false,
+			want: &CreateCustomerRequestPayloadScheme{
+				RequestFieldValues: map[string]interface{}{"customfield_10021": "2019-01-01T00:00:00Z"},
+			},
 		},
 
 		{
-			name:   "when the custom-field is not provided",
-			fields: fields{Fields: make(map[string]interface{})},
+			name:   "when the customfield id is not provided",
+			fields: fields{},
 			args: args{
-				customFieldID: "",
-				parent:        "America",
-				child:         "US",
+				id:    "",
+				value: time.Date(2019, 1, 1, 0, 0, 0, 0, time.UTC),
+			},
+			wantErr: true,
+			Err:     ErrNoCustomFieldIDError,
+		},
+
+		{
+			name:   "when the date value is not provided",
+			fields: fields{},
+			args: args{
+				id:    "customfield_10021",
+				value: time.Time{},
+			},
+			wantErr: true,
+			Err:     ErrNoDateTimeTypeError,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			c := &CreateCustomerRequestPayloadScheme{
+				Channel:             tt.fields.Channel,
+				Form:                tt.fields.Form,
+				IsAdfRequest:        tt.fields.IsAdfRequest,
+				RaiseOnBehalfOf:     tt.fields.RaiseOnBehalfOf,
+				RequestFieldValues:  tt.fields.RequestFieldValues,
+				RequestParticipants: tt.fields.RequestParticipants,
+				RequestTypeID:       tt.fields.RequestTypeID,
+				ServiceDeskID:       tt.fields.ServiceDeskID,
+			}
+
+			err := c.DateTimeCustomField(tt.args.id, tt.args.value)
+
+			if tt.wantErr {
+
+				if err != nil {
+					t.Logf("error returned: %v", err.Error())
+				}
+				assert.EqualError(t, err, tt.Err.Error())
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.want, c)
+			}
+		})
+	}
+}
+
+func TestCreateCustomerRequestPayloadScheme_DateCustomField(t *testing.T) {
+
+	type fields struct {
+		Channel             string
+		Form                *CreateCustomerRequestFormPayloadScheme
+		IsAdfRequest        bool
+		RaiseOnBehalfOf     string
+		RequestFieldValues  map[string]interface{}
+		RequestParticipants []string
+		RequestTypeID       string
+		ServiceDeskID       string
+	}
+
+	type args struct {
+		id    string
+		value time.Time
+	}
+
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		wantErr bool
+		Err     error
+		want    *CreateCustomerRequestPayloadScheme
+	}{
+		{
+			name:   "when the parameters are correct",
+			fields: fields{},
+			args: args{
+				id:    "customfield_10021",
+				value: time.Date(2019, 1, 1, 0, 0, 0, 0, time.UTC),
+			},
+			wantErr: false,
+			want: &CreateCustomerRequestPayloadScheme{
+				RequestFieldValues: map[string]interface{}{"customfield_10021": "2019-01-01"},
+			},
+		},
+
+		{
+			name:   "when the customfield id is not provided",
+			fields: fields{},
+			args: args{
+				id:    "",
+				value: time.Date(2019, 1, 1, 0, 0, 0, 0, time.UTC),
+			},
+			wantErr: true,
+			Err:     ErrNoCustomFieldIDError,
+		},
+
+		{
+			name:   "when the date value is not provided",
+			fields: fields{},
+			args: args{
+				id:    "customfield_10021",
+				value: time.Time{},
+			},
+			wantErr: true,
+			Err:     ErrNoDateTimeTypeError,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			c := &CreateCustomerRequestPayloadScheme{
+				Channel:             tt.fields.Channel,
+				Form:                tt.fields.Form,
+				IsAdfRequest:        tt.fields.IsAdfRequest,
+				RaiseOnBehalfOf:     tt.fields.RaiseOnBehalfOf,
+				RequestFieldValues:  tt.fields.RequestFieldValues,
+				RequestParticipants: tt.fields.RequestParticipants,
+				RequestTypeID:       tt.fields.RequestTypeID,
+				ServiceDeskID:       tt.fields.ServiceDeskID,
+			}
+
+			err := c.DateCustomField(tt.args.id, tt.args.value)
+
+			if tt.wantErr {
+
+				if err != nil {
+					t.Logf("error returned: %v", err.Error())
+				}
+				assert.EqualError(t, err, tt.Err.Error())
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.want, c)
+			}
+		})
+	}
+}
+
+func TestCreateCustomerRequestPayloadScheme_MultiSelectOrCheckBoxCustomField(t *testing.T) {
+
+	type fields struct {
+		Channel             string
+		Form                *CreateCustomerRequestFormPayloadScheme
+		IsAdfRequest        bool
+		RaiseOnBehalfOf     string
+		RequestFieldValues  map[string]interface{}
+		RequestParticipants []string
+		RequestTypeID       string
+		ServiceDeskID       string
+	}
+
+	type args struct {
+		id      string
+		options []string
+	}
+
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		wantErr bool
+		Err     error
+		want    *CreateCustomerRequestPayloadScheme
+	}{
+		{
+			name:   "when the parameters are correct",
+			fields: fields{},
+			args: args{
+				id:      "customfield_10021",
+				options: []string{"option 01", "option 02"},
+			},
+			wantErr: false,
+			want: &CreateCustomerRequestPayloadScheme{
+				RequestFieldValues: map[string]interface{}{"customfield_10021": []map[string]interface{}{map[string]interface{}{"value": "option 01"}, map[string]interface{}{"value": "option 02"}}},
+			},
+		},
+
+		{
+			name:   "when the customfield id is not provided",
+			fields: fields{},
+			args: args{
+				id: "",
+			},
+			wantErr: true,
+			Err:     ErrNoCustomFieldIDError,
+		},
+
+		{
+			name:   "when the option name is not provided",
+			fields: fields{},
+			args: args{
+				id: "customfield_10021",
+			},
+			wantErr: true,
+			Err:     ErrNoMultiSelectTypeError,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			c := &CreateCustomerRequestPayloadScheme{
+				Channel:             tt.fields.Channel,
+				Form:                tt.fields.Form,
+				IsAdfRequest:        tt.fields.IsAdfRequest,
+				RaiseOnBehalfOf:     tt.fields.RaiseOnBehalfOf,
+				RequestFieldValues:  tt.fields.RequestFieldValues,
+				RequestParticipants: tt.fields.RequestParticipants,
+				RequestTypeID:       tt.fields.RequestTypeID,
+				ServiceDeskID:       tt.fields.ServiceDeskID,
+			}
+
+			err := c.MultiSelectOrCheckBoxCustomField(tt.args.id, tt.args.options)
+
+			if tt.wantErr {
+
+				if err != nil {
+					t.Logf("error returned: %v", err.Error())
+				}
+				assert.EqualError(t, err, tt.Err.Error())
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.want, c)
+			}
+		})
+	}
+}
+
+func TestCreateCustomerRequestPayloadScheme_UserCustomField(t *testing.T) {
+
+	type fields struct {
+		Channel             string
+		Form                *CreateCustomerRequestFormPayloadScheme
+		IsAdfRequest        bool
+		RaiseOnBehalfOf     string
+		RequestFieldValues  map[string]interface{}
+		RequestParticipants []string
+		RequestTypeID       string
+		ServiceDeskID       string
+	}
+
+	type args struct {
+		id        string
+		accountID string
+	}
+
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		wantErr bool
+		Err     error
+		want    *CreateCustomerRequestPayloadScheme
+	}{
+		{
+			name:   "when the parameters are correct",
+			fields: fields{},
+			args: args{
+				id:        "customfield_10021",
+				accountID: "uuid-sample",
+			},
+			wantErr: false,
+			want: &CreateCustomerRequestPayloadScheme{
+				RequestFieldValues: map[string]interface{}{"customfield_10021": map[string]interface{}{"accountId": "uuid-sample"}},
+			},
+		},
+
+		{
+			name:   "when the customfield id is not provided",
+			fields: fields{},
+			args: args{
+				id: "",
+			},
+			wantErr: true,
+			Err:     ErrNoCustomFieldIDError,
+		},
+
+		{
+			name:   "when the date value is not provided",
+			fields: fields{},
+			args: args{
+				id: "customfield_10021",
+			},
+			wantErr: true,
+			Err:     ErrNoUserTypeError,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			c := &CreateCustomerRequestPayloadScheme{
+				Channel:             tt.fields.Channel,
+				Form:                tt.fields.Form,
+				IsAdfRequest:        tt.fields.IsAdfRequest,
+				RaiseOnBehalfOf:     tt.fields.RaiseOnBehalfOf,
+				RequestFieldValues:  tt.fields.RequestFieldValues,
+				RequestParticipants: tt.fields.RequestParticipants,
+				RequestTypeID:       tt.fields.RequestTypeID,
+				ServiceDeskID:       tt.fields.ServiceDeskID,
+			}
+
+			err := c.UserCustomField(tt.args.id, tt.args.accountID)
+
+			if tt.wantErr {
+
+				if err != nil {
+					t.Logf("error returned: %v", err.Error())
+				}
+				assert.EqualError(t, err, tt.Err.Error())
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.want, c)
+			}
+		})
+	}
+}
+
+func TestCreateCustomerRequestPayloadScheme_UsersCustomField(t *testing.T) {
+
+	type fields struct {
+		Channel             string
+		Form                *CreateCustomerRequestFormPayloadScheme
+		IsAdfRequest        bool
+		RaiseOnBehalfOf     string
+		RequestFieldValues  map[string]interface{}
+		RequestParticipants []string
+		RequestTypeID       string
+		ServiceDeskID       string
+	}
+
+	type args struct {
+		id      string
+		options []string
+	}
+
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		wantErr bool
+		Err     error
+		want    *CreateCustomerRequestPayloadScheme
+	}{
+		{
+			name:   "when the parameters are correct",
+			fields: fields{},
+			args: args{
+				id:      "customfield_10021",
+				options: []string{"uuid-sample", "uuid-sample-1"},
+			},
+			wantErr: false,
+			want: &CreateCustomerRequestPayloadScheme{
+				RequestFieldValues: map[string]interface{}{"customfield_10021": []map[string]interface{}{map[string]interface{}{"accountId": "uuid-sample"}, map[string]interface{}{"accountId": "uuid-sample-1"}}},
+			},
+		},
+
+		{
+			name:   "when the customfield id is not provided",
+			fields: fields{},
+			args: args{
+				id: "",
+			},
+			wantErr: true,
+			Err:     ErrNoCustomFieldIDError,
+		},
+
+		{
+			name:   "when the date value is not provided",
+			fields: fields{},
+			args: args{
+				id: "customfield_10021",
+			},
+			wantErr: true,
+			Err:     ErrNoMultiUserTypeError,
+		},
+
+		{
+			name:   "when the users slice contains an empty value",
+			fields: fields{},
+			args: args{
+				id:      "customfield_10021",
+				options: []string{"uuid-sample", ""},
+			},
+			wantErr: true,
+			Err:     ErrNoUserTypeError,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			c := &CreateCustomerRequestPayloadScheme{
+				Channel:             tt.fields.Channel,
+				Form:                tt.fields.Form,
+				IsAdfRequest:        tt.fields.IsAdfRequest,
+				RaiseOnBehalfOf:     tt.fields.RaiseOnBehalfOf,
+				RequestFieldValues:  tt.fields.RequestFieldValues,
+				RequestParticipants: tt.fields.RequestParticipants,
+				RequestTypeID:       tt.fields.RequestTypeID,
+				ServiceDeskID:       tt.fields.ServiceDeskID,
+			}
+
+			err := c.UsersCustomField(tt.args.id, tt.args.options)
+
+			if tt.wantErr {
+
+				if err != nil {
+					t.Logf("error returned: %v", err.Error())
+				}
+				assert.EqualError(t, err, tt.Err.Error())
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.want, c)
+			}
+		})
+	}
+}
+
+func TestCreateCustomerRequestPayloadScheme_CascadingCustomField(t *testing.T) {
+
+	type fields struct {
+		Channel             string
+		Form                *CreateCustomerRequestFormPayloadScheme
+		IsAdfRequest        bool
+		RaiseOnBehalfOf     string
+		RequestFieldValues  map[string]interface{}
+		RequestParticipants []string
+		RequestTypeID       string
+		ServiceDeskID       string
+	}
+
+	type args struct {
+		id, parent, child string
+	}
+
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		wantErr bool
+		Err     error
+		want    *CreateCustomerRequestPayloadScheme
+	}{
+		{
+			name:   "when the parameters are correct",
+			fields: fields{},
+			args: args{
+				id:     "customfield_10021",
+				parent: "America",
+				child:  "Costa Rica",
+			},
+			wantErr: false,
+			want: &CreateCustomerRequestPayloadScheme{
+				RequestFieldValues: map[string]interface{}{"customfield_10021": map[string]interface{}{"child": map[string]interface{}{"value": "Costa Rica"}, "value": "America"}},
+			},
+		},
+
+		{
+			name:   "when the customfield id is not provided",
+			fields: fields{},
+			args: args{
+				id: "",
 			},
 			wantErr: true,
 			Err:     ErrNoCustomFieldIDError,
@@ -1130,11 +517,9 @@ func TestCustomerRequestFields_Cascading(t *testing.T) {
 
 		{
 			name:   "when the parent value is not provided",
-			fields: fields{Fields: make(map[string]interface{})},
+			fields: fields{},
 			args: args{
-				customFieldID: "customfield_10001",
-				parent:        "",
-				child:         "US",
+				id: "customfield_10021",
 			},
 			wantErr: true,
 			Err:     ErrNoCascadingParentError,
@@ -1142,159 +527,406 @@ func TestCustomerRequestFields_Cascading(t *testing.T) {
 
 		{
 			name:   "when the child value is not provided",
-			fields: fields{Fields: make(map[string]interface{})},
+			fields: fields{},
 			args: args{
-				customFieldID: "customfield_10001",
-				parent:        "America",
-				child:         "",
+				id:     "customfield_10021",
+				parent: "America",
 			},
 			wantErr: true,
 			Err:     ErrNoCascadingChildError,
 		},
 	}
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
 
-			c := &CustomerRequestFields{
-				Fields: testCase.fields.Fields,
+			c := &CreateCustomerRequestPayloadScheme{
+				Channel:             tt.fields.Channel,
+				Form:                tt.fields.Form,
+				IsAdfRequest:        tt.fields.IsAdfRequest,
+				RaiseOnBehalfOf:     tt.fields.RaiseOnBehalfOf,
+				RequestFieldValues:  tt.fields.RequestFieldValues,
+				RequestParticipants: tt.fields.RequestParticipants,
+				RequestTypeID:       tt.fields.RequestTypeID,
+				ServiceDeskID:       tt.fields.ServiceDeskID,
 			}
 
-			err := c.Cascading(testCase.args.customFieldID, testCase.args.parent, testCase.args.child)
-			if testCase.wantErr {
+			err := c.CascadingCustomField(tt.args.id, tt.args.parent, tt.args.child)
+
+			if tt.wantErr {
 
 				if err != nil {
 					t.Logf("error returned: %v", err.Error())
 				}
-				assert.EqualError(t, err, testCase.Err.Error())
-
+				assert.EqualError(t, err, tt.Err.Error())
 			} else {
 				assert.NoError(t, err)
+				assert.Equal(t, tt.want, c)
 			}
 		})
 	}
 }
 
-func TestCreateCustomerRequestPayloadScheme_MergeFields(t *testing.T) {
-
-	fieldsMocked := &CustomerRequestFields{Fields: make(map[string]interface{})}
-
-	if err := fieldsMocked.Text("summary", "Request JSD help via REST"); err != nil {
-		t.Fatal(err)
-	}
-
-	if err := fieldsMocked.Text("description", "I need a new *mouse* for my Mac"); err != nil {
-		t.Fatal(err)
-	}
-
-	if err := fieldsMocked.Select("priority", "Major"); err != nil {
-		t.Fatal(err)
-	}
-
-	if err := fieldsMocked.Components([]string{"Jira", "Intranet"}); err != nil {
-		t.Fatal(err)
-	}
-
-	if err := fieldsMocked.Users("customfield_320239", []string{"account-id-sample"}); err != nil {
-		t.Fatal(err)
-	}
-
-	if err := fieldsMocked.Date("duedate", time.Date(2020, 1, 2, 3, 4, 5, 0, time.UTC)); err != nil {
-		log.Fatal(err)
-	}
-
-	if err := fieldsMocked.Labels([]string{"label-00", "label-01"}); err != nil {
-		log.Fatal(err)
-	}
-
-	payloadMocked := map[string]interface{}{
-		"requestFieldValues": map[string]interface{}{
-			"components":         []map[string]interface{}{map[string]interface{}{"name": "Jira"}, map[string]interface{}{"name": "Intranet"}},
-			"customfield_320239": []map[string]interface{}{map[string]interface{}{"accountId": "account-id-sample"}},
-			"description":        "I need a new *mouse* for my Mac",
-			"duedate":            "2020-01-02",
-			"labels":             []string{"label-00", "label-01"},
-			"priority":           map[string]interface{}{"value": "Major"},
-			"summary":            "Request JSD help via REST"},
-		"requestParticipants": []interface{}{"uuid-sample-1", "uuid-sample-2"},
-		"requestTypeId":       "28881",
-		"serviceDeskId":       "29990"}
+func TestCreateCustomerRequestPayloadScheme_GroupsCustomField(t *testing.T) {
 
 	type fields struct {
+		Channel             string
+		Form                *CreateCustomerRequestFormPayloadScheme
+		IsAdfRequest        bool
+		RaiseOnBehalfOf     string
+		RequestFieldValues  map[string]interface{}
 		RequestParticipants []string
-		ServiceDeskID       string
 		RequestTypeID       string
-	}
-	type args struct {
-		fields *CustomerRequestFields
+		ServiceDeskID       string
 	}
 
-	testCases := []struct {
+	type args struct {
+		id      string
+		options []string
+	}
+
+	tests := []struct {
 		name    string
 		fields  fields
 		args    args
-		want    map[string]interface{}
-		wantErr assert.ErrorAssertionFunc
+		wantErr bool
 		Err     error
+		want    *CreateCustomerRequestPayloadScheme
 	}{
 		{
-			name: "when the parameters are correct",
-			fields: fields{
-				RequestParticipants: []string{"uuid-sample-1", "uuid-sample-2"},
-				ServiceDeskID:       "29990",
-				RequestTypeID:       "28881",
-			},
+			name:   "when the parameters are correct",
+			fields: fields{},
 			args: args{
-				fields: fieldsMocked,
+				id:      "customfield_10021",
+				options: []string{"group-name-01", "group-name-02"},
 			},
-			want:    payloadMocked,
-			wantErr: assert.NoError,
+			wantErr: false,
+			want: &CreateCustomerRequestPayloadScheme{
+				RequestFieldValues: map[string]interface{}{"customfield_10021": []map[string]interface{}{map[string]interface{}{"name": "group-name-01"}, map[string]interface{}{"name": "group-name-02"}}},
+			},
 		},
 
 		{
-			name: "when the field struct is not provided",
-			fields: fields{
-				RequestParticipants: []string{"uuid-sample-1", "uuid-sample-2"},
-				ServiceDeskID:       "29990",
-				RequestTypeID:       "28881",
-			},
+			name:   "when the customfield id is not provided",
+			fields: fields{},
 			args: args{
-				fields: nil,
+				id: "",
 			},
-			wantErr: assert.Error,
-			Err:     ErrNoCustomFieldError,
+			wantErr: true,
+			Err:     ErrNoCustomFieldIDError,
 		},
 
 		{
-			name: "when the field struct does not contain values",
-			fields: fields{
-				RequestParticipants: []string{"uuid-sample-1", "uuid-sample-2"},
-				ServiceDeskID:       "29990",
-				RequestTypeID:       "28881",
-			},
+			name:   "when the groups value is not provided",
+			fields: fields{},
 			args: args{
-				fields: &CustomerRequestFields{},
+				id: "customfield_10021",
 			},
-			wantErr: assert.Error,
-			Err:     ErrNoCustomFieldError,
+			wantErr: true,
+			Err:     ErrNoGroupsNameError,
+		},
+
+		{
+			name:   "when the groups slice contains an empty element",
+			fields: fields{},
+			args: args{
+				id:      "customfield_10021",
+				options: []string{"group-name-01", ""},
+			},
+			wantErr: true,
+			Err:     ErrNoGroupNameError,
 		},
 	}
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
 
 			c := &CreateCustomerRequestPayloadScheme{
-				RequestParticipants: testCase.fields.RequestParticipants,
-				ServiceDeskID:       testCase.fields.ServiceDeskID,
-				RequestTypeID:       testCase.fields.RequestTypeID,
+				Channel:             tt.fields.Channel,
+				Form:                tt.fields.Form,
+				IsAdfRequest:        tt.fields.IsAdfRequest,
+				RaiseOnBehalfOf:     tt.fields.RaiseOnBehalfOf,
+				RequestFieldValues:  tt.fields.RequestFieldValues,
+				RequestParticipants: tt.fields.RequestParticipants,
+				RequestTypeID:       tt.fields.RequestTypeID,
+				ServiceDeskID:       tt.fields.ServiceDeskID,
 			}
 
-			got, err := c.MergeFields(testCase.args.fields)
+			err := c.GroupsCustomField(tt.args.id, tt.args.options)
 
-			if !testCase.wantErr(t, err, fmt.Sprintf("MergeFields(%v)", testCase.args.fields)) {
+			if tt.wantErr {
 
+				if err != nil {
+					t.Logf("error returned: %v", err.Error())
+				}
+				assert.EqualError(t, err, tt.Err.Error())
+			} else {
 				assert.NoError(t, err)
-				return
+				assert.Equal(t, tt.want, c)
 			}
-			assert.Equalf(t, testCase.want, got, "MergeFields(%v)", testCase.args.fields)
+		})
+	}
+}
+
+func TestCreateCustomerRequestPayloadScheme_GroupCustomField(t *testing.T) {
+
+	type fields struct {
+		Channel             string
+		Form                *CreateCustomerRequestFormPayloadScheme
+		IsAdfRequest        bool
+		RaiseOnBehalfOf     string
+		RequestFieldValues  map[string]interface{}
+		RequestParticipants []string
+		RequestTypeID       string
+		ServiceDeskID       string
+	}
+
+	type args struct {
+		id   string
+		name string
+	}
+
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		wantErr bool
+		Err     error
+		want    *CreateCustomerRequestPayloadScheme
+	}{
+		{
+			name:   "when the parameters are correct",
+			fields: fields{},
+			args: args{
+				id:   "customfield_10021",
+				name: "jira-admins",
+			},
+			wantErr: false,
+			want: &CreateCustomerRequestPayloadScheme{
+				RequestFieldValues: map[string]interface{}{"customfield_10021": map[string]interface{}{"name": "jira-admins"}},
+			},
+		},
+
+		{
+			name:   "when the customfield id is not provided",
+			fields: fields{},
+			args: args{
+				id: "",
+			},
+			wantErr: true,
+			Err:     ErrNoCustomFieldIDError,
+		},
+
+		{
+			name:   "when the group name is not provided",
+			fields: fields{},
+			args: args{
+				id: "customfield_10021",
+			},
+			wantErr: true,
+			Err:     ErrNoGroupNameError,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			c := &CreateCustomerRequestPayloadScheme{
+				Channel:             tt.fields.Channel,
+				Form:                tt.fields.Form,
+				IsAdfRequest:        tt.fields.IsAdfRequest,
+				RaiseOnBehalfOf:     tt.fields.RaiseOnBehalfOf,
+				RequestFieldValues:  tt.fields.RequestFieldValues,
+				RequestParticipants: tt.fields.RequestParticipants,
+				RequestTypeID:       tt.fields.RequestTypeID,
+				ServiceDeskID:       tt.fields.ServiceDeskID,
+			}
+
+			err := c.GroupCustomField(tt.args.id, tt.args.name)
+
+			if tt.wantErr {
+
+				if err != nil {
+					t.Logf("error returned: %v", err.Error())
+				}
+				assert.EqualError(t, err, tt.Err.Error())
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.want, c)
+			}
+		})
+	}
+}
+
+func TestCreateCustomerRequestPayloadScheme_RadioButtonOrSelectCustomField(t *testing.T) {
+
+	type fields struct {
+		Channel             string
+		Form                *CreateCustomerRequestFormPayloadScheme
+		IsAdfRequest        bool
+		RaiseOnBehalfOf     string
+		RequestFieldValues  map[string]interface{}
+		RequestParticipants []string
+		RequestTypeID       string
+		ServiceDeskID       string
+	}
+
+	type args struct {
+		id     string
+		option string
+	}
+
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		wantErr bool
+		Err     error
+		want    *CreateCustomerRequestPayloadScheme
+	}{
+		{
+			name:   "when the parameters are correct",
+			fields: fields{},
+			args: args{
+				id:     "customfield_10021",
+				option: "Option 01",
+			},
+			wantErr: false,
+			want: &CreateCustomerRequestPayloadScheme{
+				RequestFieldValues: map[string]interface{}{"customfield_10021": map[string]interface{}{"value": "Option 01"}},
+			},
+		},
+
+		{
+			name:   "when the customfield id is not provided",
+			fields: fields{},
+			args: args{
+				id: "",
+			},
+			wantErr: true,
+			Err:     ErrNoCustomFieldIDError,
+		},
+
+		{
+			name:   "when the option name is not provided",
+			fields: fields{},
+			args: args{
+				id: "customfield_10021",
+			},
+			wantErr: true,
+			Err:     ErrNoSelectTypeError,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			c := &CreateCustomerRequestPayloadScheme{
+				Channel:             tt.fields.Channel,
+				Form:                tt.fields.Form,
+				IsAdfRequest:        tt.fields.IsAdfRequest,
+				RaiseOnBehalfOf:     tt.fields.RaiseOnBehalfOf,
+				RequestFieldValues:  tt.fields.RequestFieldValues,
+				RequestParticipants: tt.fields.RequestParticipants,
+				RequestTypeID:       tt.fields.RequestTypeID,
+				ServiceDeskID:       tt.fields.ServiceDeskID,
+			}
+
+			err := c.RadioButtonOrSelectCustomField(tt.args.id, tt.args.option)
+
+			if tt.wantErr {
+
+				if err != nil {
+					t.Logf("error returned: %v", err.Error())
+				}
+				assert.EqualError(t, err, tt.Err.Error())
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.want, c)
+			}
+		})
+	}
+}
+
+func TestCreateCustomerRequestPayloadScheme_Components(t *testing.T) {
+
+	type fields struct {
+		Channel             string
+		Form                *CreateCustomerRequestFormPayloadScheme
+		IsAdfRequest        bool
+		RaiseOnBehalfOf     string
+		RequestFieldValues  map[string]interface{}
+		RequestParticipants []string
+		RequestTypeID       string
+		ServiceDeskID       string
+	}
+
+	type args struct {
+		components []string
+	}
+
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		wantErr bool
+		Err     error
+		want    *CreateCustomerRequestPayloadScheme
+	}{
+		{
+			name:   "when the parameters are correct",
+			fields: fields{},
+			args: args{
+				components: []string{"Jira Cloud", "Confluence Cloud"},
+			},
+			wantErr: false,
+			want: &CreateCustomerRequestPayloadScheme{
+				RequestFieldValues: map[string]interface{}{"components": []map[string]interface{}{map[string]interface{}{"name": "Jira Cloud"}, map[string]interface{}{"name": "Confluence Cloud"}}},
+			},
+		},
+
+		{
+			name:   "when the components are not provided",
+			fields: fields{},
+			args: args{
+				components: nil,
+			},
+			wantErr: true,
+			Err:     ErrNoComponentsError,
+		},
+
+		{
+			name:   "when the one component on the slice is empty",
+			fields: fields{},
+			args: args{
+				components: []string{"Jira Cloud", ""},
+			},
+			wantErr: true,
+			Err:     ErrNCoComponentError,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			c := &CreateCustomerRequestPayloadScheme{
+				Channel:             tt.fields.Channel,
+				Form:                tt.fields.Form,
+				IsAdfRequest:        tt.fields.IsAdfRequest,
+				RaiseOnBehalfOf:     tt.fields.RaiseOnBehalfOf,
+				RequestFieldValues:  tt.fields.RequestFieldValues,
+				RequestParticipants: tt.fields.RequestParticipants,
+				RequestTypeID:       tt.fields.RequestTypeID,
+				ServiceDeskID:       tt.fields.ServiceDeskID,
+			}
+
+			err := c.Components(tt.args.components)
+
+			if tt.wantErr {
+
+				if err != nil {
+					t.Logf("error returned: %v", err.Error())
+				}
+				assert.EqualError(t, err, tt.Err.Error())
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.want, c)
+			}
 		})
 	}
 }

--- a/service/sm/request.go
+++ b/service/sm/request.go
@@ -14,7 +14,7 @@ type RequestConnector interface {
 	// POST /rest/servicedeskapi/request
 	//
 	// https://docs.go-atlassian.io/jira-service-management/request#create-customer-request
-	Create(ctx context.Context, payload *model.CreateCustomerRequestPayloadScheme, fields *model.CustomerRequestFields) (*model.CustomerRequestScheme, *model.ResponseScheme, error)
+	Create(ctx context.Context, payload *model.CreateCustomerRequestPayloadScheme) (*model.CustomerRequestScheme, *model.ResponseScheme, error)
 
 	// Gets returns all customer requests for the user executing the query.
 	//


### PR DESCRIPTION
1. Removed the necessity to use two struct when you want to create a new ITSM request.

2. The CreateCustomerRequestPayloadScheme contains multiple methods to inject the customfields based on the field type.

3. Added the possibility to embed form on the CreateCustomerRequestPayloadScheme struct.

4. Added the IsAdfRequest and RaiseOnBehalfOf tags on the CreateCustomerRequestPayloadScheme struct.

5. Changed the RequestConnector.Create method contract removing the CustomerRequestFields struct.

6. Added the new customfield handling implementation with a 100% of coverage.