### PR TITLE
Add ObjectTypeAttribute Payload for the creation and the update of the Assets Object Type Attribute

### DIFF
--- a/assets/internal/object_type_attribute_impl.go
+++ b/assets/internal/object_type_attribute_impl.go
@@ -25,7 +25,7 @@ type ObjectTypeAttributeService struct {
 // POST /jsm/assets/workspace/{workspaceId}/v1/objecttypeattribute/{objectTypeId}
 //
 // https://docs.go-atlassian.io/jira-assets/object/type/attribute#create-object-type-attribute
-func (o *ObjectTypeAttributeService) Create(ctx context.Context, workspaceID, objectTypeID string, payload *model.ObjectTypeAttributeScheme) (*model.ObjectTypeAttributeScheme, *model.ResponseScheme, error) {
+func (o *ObjectTypeAttributeService) Create(ctx context.Context, workspaceID, objectTypeID string, payload *model.ObjectTypeAttributePayloadScheme) (*model.ObjectTypeAttributeScheme, *model.ResponseScheme, error) {
 	return o.internalClient.Create(ctx, workspaceID, objectTypeID, payload)
 }
 
@@ -51,7 +51,7 @@ type internalObjectTypeAttributeImpl struct {
 	c service.Connector
 }
 
-func (i *internalObjectTypeAttributeImpl) Create(ctx context.Context, workspaceID, objectTypeID string, payload *model.ObjectTypeAttributeScheme) (*model.ObjectTypeAttributeScheme, *model.ResponseScheme, error) {
+func (i *internalObjectTypeAttributeImpl) Create(ctx context.Context, workspaceID, objectTypeID string, payload *model.ObjectTypeAttributePayloadScheme) (*model.ObjectTypeAttributeScheme, *model.ResponseScheme, error) {
 
 	if workspaceID == "" {
 		return nil, nil, model.ErrNoWorkspaceIDError
@@ -77,7 +77,7 @@ func (i *internalObjectTypeAttributeImpl) Create(ctx context.Context, workspaceI
 	return attribute, res, nil
 }
 
-func (i *internalObjectTypeAttributeImpl) Update(ctx context.Context, workspaceID, objectTypeID, attributeID string, payload *model.ObjectTypeAttributeScheme) (*model.ObjectTypeAttributeScheme, *model.ResponseScheme, error) {
+func (i *internalObjectTypeAttributeImpl) Update(ctx context.Context, workspaceID, objectTypeID, attributeID string, payload *model.ObjectTypeAttributePayloadScheme) (*model.ObjectTypeAttributeScheme, *model.ResponseScheme, error) {
 
 	if workspaceID == "" {
 		return nil, nil, model.ErrNoWorkspaceIDError

--- a/assets/internal/object_type_attribute_impl.go
+++ b/assets/internal/object_type_attribute_impl.go
@@ -34,7 +34,7 @@ func (o *ObjectTypeAttributeService) Create(ctx context.Context, workspaceID, ob
 // PUT /jsm/assets/workspace/{workspaceId}/v1/objecttypeattribute/{objectTypeId}/{id}
 //
 // https://docs.go-atlassian.io/jira-assets/object/type/attribute#update-object-type-attribute
-func (o *ObjectTypeAttributeService) Update(ctx context.Context, workspaceID, objectTypeID, attributeID string, payload *model.ObjectTypeAttributeScheme) (*model.ObjectTypeAttributeScheme, *model.ResponseScheme, error) {
+func (o *ObjectTypeAttributeService) Update(ctx context.Context, workspaceID, objectTypeID, attributeID string, payload *model.ObjectTypeAttributePayloadScheme) (*model.ObjectTypeAttributeScheme, *model.ResponseScheme, error) {
 	return o.internalClient.Update(ctx, workspaceID, objectTypeID, attributeID, payload)
 }
 

--- a/assets/internal/object_type_attribute_impl_test.go
+++ b/assets/internal/object_type_attribute_impl_test.go
@@ -12,19 +12,17 @@ import (
 )
 
 func Test_internalObjectTypeAttributeImpl_Create(t *testing.T) {
-
+	attributeType := 0
+	defaultTypeId := 0
 	payloadMocked := &model.ObjectTypeAttributePayloadScheme{
 		Name:        		"Geolocation",
 		Label:  	 	 false,
-		Type:       		 0,
+		Type:       		 &attributeType,
 		Description: 		 "",
-		DefaultTypeId: 		 0,
+		DefaultTypeId: 		 &defaultTypeId,
 		TypeValue:               "",
 		TypeValueMulti:          nil,
 		AdditionalValue:         "",
-		ReferenceType:           nil,
-		ReferenceObjectTypeId:   "",
-		ReferenceObjectType:     nil,
 		Editable:                false,
 		System:                  false,
 		Indexed:                 false,

--- a/assets/internal/object_type_attribute_impl_test.go
+++ b/assets/internal/object_type_attribute_impl_test.go
@@ -23,16 +23,10 @@ func Test_internalObjectTypeAttributeImpl_Create(t *testing.T) {
 		TypeValue:               "",
 		TypeValueMulti:          nil,
 		AdditionalValue:         "",
-		Editable:                false,
-		System:                  false,
-		Indexed:                 false,
-		Sortable:                false,
 		Summable:                false,
 		MinimumCardinality:      0,
 		MaximumCardinality:      0,
 		Suffix:                  "",
-		Removable:               false,
-		ObjectAttributeExists:   false,
 		Hidden:                  false,
 		IncludeChildObjectTypes: false,
 		UniqueAttribute:         false,
@@ -40,7 +34,6 @@ func Test_internalObjectTypeAttributeImpl_Create(t *testing.T) {
 		Iql:                     "",
 		QlQuery:                 "",
 		Options:                 "",
-		Position:                6,
 	}
 
 	type fields struct {

--- a/assets/internal/object_type_attribute_impl_test.go
+++ b/assets/internal/object_type_attribute_impl_test.go
@@ -13,19 +13,16 @@ import (
 
 func Test_internalObjectTypeAttributeImpl_Create(t *testing.T) {
 
-	payloadMocked := &model.ObjectTypeAttributeScheme{
-		WorkspaceId: "g2778e1d-939d-581d-c8e2-9d5g59de456b",
-		GlobalId:    "g2778e1d-939d-581d-c8e2-9d5g59de456b:1330",
-		ID:          "1330",
-		ObjectType:  nil,
-		Name:        "Geolocation",
-		Label:       false,
-		Type:        0,
-		Description: "",
-		DefaultType: &model.ObjectTypeAssetAttributeDefaultTypeScheme{
-			ID:   0,
-			Name: "Text",
-		},
+	payloadMocked := &model.ObjectTypeAttributePayloadScheme{
+		WorkspaceId: 		"g2778e1d-939d-581d-c8e2-9d5g59de456b",
+		GlobalId:    		"g2778e1d-939d-581d-c8e2-9d5g59de456b:1330",
+		ID:          		"1330",
+		ObjectType:  		nil,
+		Name:        		"Geolocation",
+		Label:  	 	 false,
+		Type:       		 0,
+		Description: 		 "",
+		DefaultTypeId: 		 0,
 		TypeValue:               "",
 		TypeValueMulti:          nil,
 		AdditionalValue:         "",
@@ -182,19 +179,16 @@ func Test_internalObjectTypeAttributeImpl_Create(t *testing.T) {
 
 func Test_internalObjectTypeAttributeImpl_Update(t *testing.T) {
 
-	payloadMocked := &model.ObjectTypeAttributeScheme{
-		WorkspaceId: "g2778e1d-939d-581d-c8e2-9d5g59de456b",
-		GlobalId:    "g2778e1d-939d-581d-c8e2-9d5g59de456b:1330",
-		ID:          "1330",
-		ObjectType:  nil,
-		Name:        "Geolocation",
-		Label:       false,
-		Type:        0,
-		Description: "",
-		DefaultType: &model.ObjectTypeAssetAttributeDefaultTypeScheme{
-			ID:   0,
-			Name: "Text",
-		},
+	payloadMocked := &model.ObjectTypeAttributePayloadScheme{
+		WorkspaceId: 		 "g2778e1d-939d-581d-c8e2-9d5g59de456b",
+		GlobalId:    		 "g2778e1d-939d-581d-c8e2-9d5g59de456b:1330",
+		ID:          		 "1330",
+		ObjectType:  		 nil,
+		Name:        		 "Geolocation",
+		Label:       		 false,
+		Type:        		 0,
+		Description: 		 "",
+		DefaultTypeId: 		 0,
 		TypeValue:               "",
 		TypeValueMulti:          nil,
 		AdditionalValue:         "",

--- a/assets/internal/object_type_attribute_impl_test.go
+++ b/assets/internal/object_type_attribute_impl_test.go
@@ -14,10 +14,6 @@ import (
 func Test_internalObjectTypeAttributeImpl_Create(t *testing.T) {
 
 	payloadMocked := &model.ObjectTypeAttributePayloadScheme{
-		WorkspaceId: 		"g2778e1d-939d-581d-c8e2-9d5g59de456b",
-		GlobalId:    		"g2778e1d-939d-581d-c8e2-9d5g59de456b:1330",
-		ID:          		"1330",
-		ObjectType:  		nil,
 		Name:        		"Geolocation",
 		Label:  	 	 false,
 		Type:       		 0,

--- a/pkg/infra/models/assets_object.go
+++ b/pkg/infra/models/assets_object.go
@@ -105,13 +105,13 @@ type ObjectTypeAttributePayloadScheme struct {
 	Name                    string   `json:"name,omitempty"`
 	Label                   bool     `json:"label,omitempty"`
 	Description             string   `json:"description,omitempty"`
-	Type                    int      `json:"type,omitempty"`
-	DefaultTypeId		int      `json:defaultTypeId,omitempty"`
+	Type                    *int      `json:"type,omitempty"`
+	DefaultTypeId		*int      `json:defaultTypeId,omitempty"`
  	TypeValue               string   `json:"typeValue,omitempty"`
 	TypeValueMulti          []string `json:"typeValueMulti,omitempty"`
 	AdditionalValue         string   `json:"additionalValue,omitempty"`
-	MinimumCardinality      int      `json:"minimumCardinality,omitempty"`
-	MaximumCardinality      int      `json:"maximumCardinality,omitempty"`
+	MinimumCardinality      *int      `json:"minimumCardinality,omitempty"`
+	MaximumCardinality      *int      `json:"maximumCardinality,omitempty"`
 	Suffix                  string   `json:"suffix,omitempty"`
 	IncludeChildObjectTypes bool     `json:"includeChildObjectTypes,omitempty"`
 	Hidden                  bool     `json:"hidden,omitempty"`

--- a/pkg/infra/models/assets_object.go
+++ b/pkg/infra/models/assets_object.go
@@ -101,6 +101,28 @@ type ObjectAttributeScheme struct {
 	ObjectAttributeValues []*ObjectTypeAssetAttributeValueScheme `json:"objectAttributeValues,omitempty"`
 }
 
+type ObjectTypeAttributePayloadScheme struct {
+	Name                    string   `json:"name,omitempty"`
+	Label                   bool     `json:"label,omitempty"`
+	Description             string   `json:"description,omitempty"`
+	Type                    int      `json:"type,omitempty"`
+	DefaultTypeId		int      `json:defaultTypeId,omitempty"`
+ 	TypeValue               string   `json:"typeValue,omitempty"`
+	TypeValueMulti          []string `json:"typeValueMulti,omitempty"`
+	AdditionalValue         string   `json:"additionalValue,omitempty"`
+	MinimumCardinality      int      `json:"minimumCardinality,omitempty"`
+	MaximumCardinality      int      `json:"maximumCardinality,omitempty"`
+	Suffix                  string   `json:"suffix,omitempty"`
+	IncludeChildObjectTypes bool     `json:"includeChildObjectTypes,omitempty"`
+	Hidden                  bool     `json:"hidden,omitempty"`
+	UniqueAttribute         bool     `json:"uniqueAttribute,omitempty"`
+	Summable                bool     `json:"summable,omitempty"`
+	RegexValidation         string   `json:"regexValidation,omitempty"`
+	QlQuery                 string   `json:"qlQuery,omitempty"`
+	Iql                     string   `json:"iql,omitempty"`
+	Options                 string   `json:"options,omitempty"`
+}
+
 type ObjectTypeAttributeScheme struct {
 	WorkspaceId             string                                       `json:"workspaceId,omitempty"`
 	GlobalId                string                                       `json:"globalId,omitempty"`

--- a/service/assets/object_type_attribute.go
+++ b/service/assets/object_type_attribute.go
@@ -14,7 +14,7 @@ type ObjectTypeAttributeConnector interface {
 	// POST /jsm/assets/workspace/{workspaceId}/v1/objecttypeattribute/{objectTypeId}
 	//
 	// https://docs.go-atlassian.io/jira-assets/object/type/attribute#create-object-type-attribute
-	Create(ctx context.Context, workspaceID, objectTypeID string, payload *models.ObjectTypeAttributeScheme) (
+	Create(ctx context.Context, workspaceID, objectTypeID string, payload *models.ObjectTypeAttributePayloadScheme) (
 		*models.ObjectTypeAttributeScheme, *models.ResponseScheme, error)
 
 	// Update updates an existing object type attribute
@@ -22,7 +22,7 @@ type ObjectTypeAttributeConnector interface {
 	// PUT /jsm/assets/workspace/{workspaceId}/v1/objecttypeattribute/{objectTypeId}/{id}
 	//
 	// https://docs.go-atlassian.io/jira-assets/object/type/attribute#update-object-type-attribute
-	Update(ctx context.Context, workspaceID, objectTypeID, attributeID string, payload *models.ObjectTypeAttributeScheme) (
+	Update(ctx context.Context, workspaceID, objectTypeID, attributeID string, payload *models.ObjectTypeAttributePayloadScheme) (
 		*models.ObjectTypeAttributeScheme, *models.ResponseScheme, error)
 
 	// Delete deletes an existing object type attribute


### PR DESCRIPTION
Hello,

Like explain here : https://developer.atlassian.com/cloud/assets/rest/api-group-objecttypeattribute/#api-objecttypeattribute-objecttypeid-post, the type of the payload of the objecttypeattribute is not an ObjectTypeAttribute object.
In fact, for the creation of an attribute with the type 0 (default type), we need to fill the defaultTypeId parameter.
This parameter is missing in the objectTypeAttribute object.