### PR TITLE
Replace service desk id with string instead of int

### DIFF
--- a/jira/sm/internal/customer_impl.go
+++ b/jira/sm/internal/customer_impl.go
@@ -3,12 +3,13 @@ package internal
 import (
 	"context"
 	"fmt"
-	model "github.com/ctreminiom/go-atlassian/pkg/infra/models"
-	"github.com/ctreminiom/go-atlassian/service"
-	"github.com/ctreminiom/go-atlassian/service/sm"
 	"net/http"
 	"net/url"
 	"strconv"
+
+	model "github.com/ctreminiom/go-atlassian/pkg/infra/models"
+	"github.com/ctreminiom/go-atlassian/service"
+	"github.com/ctreminiom/go-atlassian/service/sm"
 )
 
 func NewCustomerService(client service.Connector, version string) *CustomerService {
@@ -42,7 +43,7 @@ func (c *CustomerService) Create(ctx context.Context, email, displayName string)
 // GET /rest/servicedeskapi/servicedesk/{serviceDeskId}/customer
 //
 // https://docs.go-atlassian.io/jira-service-management-cloud/customer#get-customers
-func (c *CustomerService) Gets(ctx context.Context, serviceDeskID int, query string, start, limit int) (*model.CustomerPageScheme, *model.ResponseScheme, error) {
+func (c *CustomerService) Gets(ctx context.Context, serviceDeskID string, query string, start, limit int) (*model.CustomerPageScheme, *model.ResponseScheme, error) {
 	return c.internalClient.Gets(ctx, serviceDeskID, query, start, limit)
 }
 
@@ -51,7 +52,7 @@ func (c *CustomerService) Gets(ctx context.Context, serviceDeskID int, query str
 // POST /rest/servicedeskapi/servicedesk/{serviceDeskId}/customer
 //
 // https://docs.go-atlassian.io/jira-service-management-cloud/customer#add-customers
-func (c *CustomerService) Add(ctx context.Context, serviceDeskID int, accountIDs []string) (*model.ResponseScheme, error) {
+func (c *CustomerService) Add(ctx context.Context, serviceDeskID string, accountIDs []string) (*model.ResponseScheme, error) {
 	return c.internalClient.Add(ctx, serviceDeskID, accountIDs)
 }
 
@@ -60,7 +61,7 @@ func (c *CustomerService) Add(ctx context.Context, serviceDeskID int, accountIDs
 // DELETE /rest/servicedeskapi/servicedesk/{serviceDeskId}/customer
 //
 // https://docs.go-atlassian.io/jira-service-management-cloud/customer#remove-customers
-func (c *CustomerService) Remove(ctx context.Context, serviceDeskID int, accountIDs []string) (*model.ResponseScheme, error) {
+func (c *CustomerService) Remove(ctx context.Context, serviceDeskID string, accountIDs []string) (*model.ResponseScheme, error) {
 	return c.internalClient.Remove(ctx, serviceDeskID, accountIDs)
 }
 
@@ -92,7 +93,7 @@ func (i *internalCustomerImpl) Create(ctx context.Context, email, displayName st
 	return customer, res, nil
 }
 
-func (i *internalCustomerImpl) Gets(ctx context.Context, serviceDeskID int, query string, start, limit int) (*model.CustomerPageScheme, *model.ResponseScheme, error) {
+func (i *internalCustomerImpl) Gets(ctx context.Context, serviceDeskID string, query string, start, limit int) (*model.CustomerPageScheme, *model.ResponseScheme, error) {
 
 	params := url.Values{}
 	params.Add("start", strconv.Itoa(start))
@@ -118,9 +119,9 @@ func (i *internalCustomerImpl) Gets(ctx context.Context, serviceDeskID int, quer
 	return page, res, nil
 }
 
-func (i *internalCustomerImpl) Add(ctx context.Context, serviceDeskID int, accountIDs []string) (*model.ResponseScheme, error) {
+func (i *internalCustomerImpl) Add(ctx context.Context, serviceDeskID string, accountIDs []string) (*model.ResponseScheme, error) {
 
-	if serviceDeskID == 0 {
+	if serviceDeskID == "" {
 		return nil, model.ErrNoServiceDeskIDError
 	}
 
@@ -142,9 +143,9 @@ func (i *internalCustomerImpl) Add(ctx context.Context, serviceDeskID int, accou
 	return i.c.Call(req, nil)
 }
 
-func (i *internalCustomerImpl) Remove(ctx context.Context, serviceDeskID int, accountIDs []string) (*model.ResponseScheme, error) {
+func (i *internalCustomerImpl) Remove(ctx context.Context, serviceDeskID string, accountIDs []string) (*model.ResponseScheme, error) {
 
-	if serviceDeskID == 0 {
+	if serviceDeskID == "" {
 		return nil, model.ErrNoServiceDeskIDError
 	}
 

--- a/jira/sm/internal/customer_impl_test.go
+++ b/jira/sm/internal/customer_impl_test.go
@@ -3,12 +3,14 @@ package internal
 import (
 	"context"
 	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
 	model "github.com/ctreminiom/go-atlassian/pkg/infra/models"
 	"github.com/ctreminiom/go-atlassian/service"
 	"github.com/ctreminiom/go-atlassian/service/mocks"
-	"github.com/stretchr/testify/assert"
-	"net/http"
-	"testing"
 )
 
 func Test_internalCustomerImpl_Create(t *testing.T) {
@@ -151,7 +153,7 @@ func Test_internalCustomerImpl_Gets(t *testing.T) {
 
 	type args struct {
 		ctx           context.Context
-		serviceDeskID int
+		serviceDeskID string
 		query         string
 		start, limit  int
 	}
@@ -168,7 +170,7 @@ func Test_internalCustomerImpl_Gets(t *testing.T) {
 			name: "when the parameters are correct",
 			args: args{
 				ctx:           context.Background(),
-				serviceDeskID: 10001,
+				serviceDeskID: "10001",
 				query:         "Carlos T",
 				start:         100,
 				limit:         50,
@@ -198,7 +200,7 @@ func Test_internalCustomerImpl_Gets(t *testing.T) {
 			name: "when the http call cannot be executed",
 			args: args{
 				ctx:           context.Background(),
-				serviceDeskID: 10001,
+				serviceDeskID: "10001",
 				query:         "Carlos T",
 				start:         100,
 				limit:         50,
@@ -230,7 +232,7 @@ func Test_internalCustomerImpl_Gets(t *testing.T) {
 			name: "when the request cannot be created",
 			args: args{
 				ctx:           context.Background(),
-				serviceDeskID: 10001,
+				serviceDeskID: "10001",
 				query:         "Carlos T",
 				start:         100,
 				limit:         50,
@@ -292,7 +294,7 @@ func Test_internalCustomerImpl_Add(t *testing.T) {
 
 	type args struct {
 		ctx           context.Context
-		serviceDeskID int
+		serviceDeskID string
 		accountIDs    []string
 	}
 
@@ -308,7 +310,7 @@ func Test_internalCustomerImpl_Add(t *testing.T) {
 			name: "when the parameters are correct",
 			args: args{
 				ctx:           context.Background(),
-				serviceDeskID: 10001,
+				serviceDeskID: "10001",
 				accountIDs:    []string{"uuid-sample-1", "uuid-sample-2"},
 			},
 			on: func(fields *fields) {
@@ -336,7 +338,7 @@ func Test_internalCustomerImpl_Add(t *testing.T) {
 			name: "when the http call cannot be executed",
 			args: args{
 				ctx:           context.Background(),
-				serviceDeskID: 10001,
+				serviceDeskID: "10001",
 				accountIDs:    []string{"uuid-sample-1", "uuid-sample-2"},
 			},
 			on: func(fields *fields) {
@@ -366,7 +368,7 @@ func Test_internalCustomerImpl_Add(t *testing.T) {
 			name: "when the request cannot be created",
 			args: args{
 				ctx:           context.Background(),
-				serviceDeskID: 10001,
+				serviceDeskID: "10001",
 				accountIDs:    []string{"uuid-sample-1", "uuid-sample-2"},
 			},
 			on: func(fields *fields) {
@@ -400,7 +402,7 @@ func Test_internalCustomerImpl_Add(t *testing.T) {
 			name: "when the account ids are not provided",
 			args: args{
 				ctx:           context.Background(),
-				serviceDeskID: 10001,
+				serviceDeskID: "10001",
 			},
 			wantErr: true,
 			Err:     model.ErrNoAccountSliceError,
@@ -443,7 +445,7 @@ func Test_internalCustomerImpl_Remove(t *testing.T) {
 
 	type args struct {
 		ctx           context.Context
-		serviceDeskID int
+		serviceDeskID string
 		accountIDs    []string
 	}
 
@@ -459,7 +461,7 @@ func Test_internalCustomerImpl_Remove(t *testing.T) {
 			name: "when the parameters are correct",
 			args: args{
 				ctx:           context.Background(),
-				serviceDeskID: 10001,
+				serviceDeskID: "10001",
 				accountIDs:    []string{"uuid-sample-1", "uuid-sample-2"},
 			},
 			on: func(fields *fields) {
@@ -487,7 +489,7 @@ func Test_internalCustomerImpl_Remove(t *testing.T) {
 			name: "when the http call cannot be executed",
 			args: args{
 				ctx:           context.Background(),
-				serviceDeskID: 10001,
+				serviceDeskID: "10001",
 				accountIDs:    []string{"uuid-sample-1", "uuid-sample-2"},
 			},
 			on: func(fields *fields) {
@@ -517,7 +519,7 @@ func Test_internalCustomerImpl_Remove(t *testing.T) {
 			name: "when the request cannot be created",
 			args: args{
 				ctx:           context.Background(),
-				serviceDeskID: 10001,
+				serviceDeskID: "10001",
 				accountIDs:    []string{"uuid-sample-1", "uuid-sample-2"},
 			},
 			on: func(fields *fields) {
@@ -551,7 +553,7 @@ func Test_internalCustomerImpl_Remove(t *testing.T) {
 			name: "when the account ids are not provided",
 			args: args{
 				ctx:           context.Background(),
-				serviceDeskID: 10001,
+				serviceDeskID: "10001",
 			},
 			wantErr: true,
 			Err:     model.ErrNoAccountSliceError,

--- a/service/sm/customer.go
+++ b/service/sm/customer.go
@@ -2,6 +2,7 @@ package sm
 
 import (
 	"context"
+
 	model "github.com/ctreminiom/go-atlassian/pkg/infra/models"
 )
 
@@ -25,19 +26,19 @@ type CustomerConnector interface {
 	// GET /rest/servicedeskapi/servicedesk/{serviceDeskId}/customer
 	//
 	// https://docs.go-atlassian.io/jira-service-management-cloud/customer#get-customers
-	Gets(ctx context.Context, serviceDeskID int, query string, start, limit int) (*model.CustomerPageScheme, *model.ResponseScheme, error)
+	Gets(ctx context.Context, serviceDeskID string, query string, start, limit int) (*model.CustomerPageScheme, *model.ResponseScheme, error)
 
 	// Add adds one or more customers to a service desk.
 	//
 	// POST /rest/servicedeskapi/servicedesk/{serviceDeskId}/customer
 	//
 	// https://docs.go-atlassian.io/jira-service-management-cloud/customer#add-customers
-	Add(ctx context.Context, serviceDeskID int, accountIDs []string) (*model.ResponseScheme, error)
+	Add(ctx context.Context, serviceDeskID string, accountIDs []string) (*model.ResponseScheme, error)
 
 	// Remove removes one or more customers from a service desk. The service desk must have closed access
 	//
 	// DELETE /rest/servicedeskapi/servicedesk/{serviceDeskId}/customer
 	//
 	// https://docs.go-atlassian.io/jira-service-management-cloud/customer#remove-customers
-	Remove(ctx context.Context, serviceDeskID int, accountIDs []string) (*model.ResponseScheme, error)
+	Remove(ctx context.Context, serviceDeskID string, accountIDs []string) (*model.ResponseScheme, error)
 }


### PR DESCRIPTION
Based on the official document those URLs wants a string for `serviceDeskID`.

https://developer.atlassian.com/cloud/jira/service-desk/rest/api-group-servicedesk/#api-rest-servicedeskapi-servicedesk-servicedeskid-customer-get

This will be a breaking change.