### PR TITLE
Replace service desk id with string instead of int

### DIFF
--- a/jira/sm/internal/service_desk_impl.go
+++ b/jira/sm/internal/service_desk_impl.go
@@ -4,14 +4,15 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	model "github.com/ctreminiom/go-atlassian/pkg/infra/models"
-	"github.com/ctreminiom/go-atlassian/service"
-	"github.com/ctreminiom/go-atlassian/service/sm"
 	"io"
 	"mime/multipart"
 	"net/http"
 	"net/url"
 	"strconv"
+
+	model "github.com/ctreminiom/go-atlassian/pkg/infra/models"
+	"github.com/ctreminiom/go-atlassian/service"
+	"github.com/ctreminiom/go-atlassian/service/sm"
 )
 
 func NewServiceDeskService(client service.Connector, version string, queue *QueueService) (*ServiceDeskService, error) {
@@ -49,7 +50,7 @@ func (s *ServiceDeskService) Gets(ctx context.Context, start, limit int) (*model
 // GET /rest/servicedeskapi/servicedesk/{serviceDeskId}
 //
 // https://docs.go-atlassian.io/jira-service-management-cloud/request/service-desk#get-service-desk-by-id
-func (s *ServiceDeskService) Get(ctx context.Context, serviceDeskID int) (*model.ServiceDeskScheme, *model.ResponseScheme, error) {
+func (s *ServiceDeskService) Get(ctx context.Context, serviceDeskID string) (*model.ServiceDeskScheme, *model.ResponseScheme, error) {
 	return s.internalClient.Get(ctx, serviceDeskID)
 }
 
@@ -58,7 +59,7 @@ func (s *ServiceDeskService) Get(ctx context.Context, serviceDeskID int) (*model
 // POST /rest/servicedeskapi/servicedesk/{serviceDeskId}/attachTemporaryFile
 //
 // https://docs.go-atlassian.io/jira-service-management-cloud/request/service-desk#attach-temporary-file
-func (s *ServiceDeskService) Attach(ctx context.Context, serviceDeskID int, fileName string, file io.Reader) (*model.ServiceDeskTemporaryFileScheme, *model.ResponseScheme, error) {
+func (s *ServiceDeskService) Attach(ctx context.Context, serviceDeskID string, fileName string, file io.Reader) (*model.ServiceDeskTemporaryFileScheme, *model.ResponseScheme, error) {
 	return s.internalClient.Attach(ctx, serviceDeskID, fileName, file)
 }
 
@@ -89,9 +90,9 @@ func (i *internalServiceDeskImpl) Gets(ctx context.Context, start, limit int) (*
 	return page, res, nil
 }
 
-func (i *internalServiceDeskImpl) Get(ctx context.Context, serviceDeskID int) (*model.ServiceDeskScheme, *model.ResponseScheme, error) {
+func (i *internalServiceDeskImpl) Get(ctx context.Context, serviceDeskID string) (*model.ServiceDeskScheme, *model.ResponseScheme, error) {
 
-	if serviceDeskID == 0 {
+	if serviceDeskID == "" {
 		return nil, nil, model.ErrNoServiceDeskIDError
 	}
 
@@ -111,9 +112,9 @@ func (i *internalServiceDeskImpl) Get(ctx context.Context, serviceDeskID int) (*
 	return serviceDesk, res, nil
 }
 
-func (i *internalServiceDeskImpl) Attach(ctx context.Context, serviceDeskID int, fileName string, file io.Reader) (*model.ServiceDeskTemporaryFileScheme, *model.ResponseScheme, error) {
+func (i *internalServiceDeskImpl) Attach(ctx context.Context, serviceDeskID string, fileName string, file io.Reader) (*model.ServiceDeskTemporaryFileScheme, *model.ResponseScheme, error) {
 
-	if serviceDeskID == 0 {
+	if serviceDeskID == "" {
 		return nil, nil, model.ErrNoServiceDeskIDError
 	}
 

--- a/jira/sm/internal/service_desk_impl_test.go
+++ b/jira/sm/internal/service_desk_impl_test.go
@@ -3,16 +3,18 @@ package internal
 import (
 	"context"
 	"errors"
-	model "github.com/ctreminiom/go-atlassian/pkg/infra/models"
-	"github.com/ctreminiom/go-atlassian/service"
-	"github.com/ctreminiom/go-atlassian/service/mocks"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 	"io"
 	"net/http"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	model "github.com/ctreminiom/go-atlassian/pkg/infra/models"
+	"github.com/ctreminiom/go-atlassian/service"
+	"github.com/ctreminiom/go-atlassian/service/mocks"
 )
 
 func Test_internalServiceDeskImpl_Gets(t *testing.T) {
@@ -156,7 +158,7 @@ func Test_internalServiceDeskImpl_Get(t *testing.T) {
 
 	type args struct {
 		ctx           context.Context
-		serviceDeskID int
+		serviceDeskID string
 	}
 
 	testCases := []struct {
@@ -171,7 +173,7 @@ func Test_internalServiceDeskImpl_Get(t *testing.T) {
 			name: "when the parameters are correct",
 			args: args{
 				ctx:           context.Background(),
-				serviceDeskID: 10001,
+				serviceDeskID: "10001",
 			},
 			on: func(fields *fields) {
 
@@ -198,7 +200,7 @@ func Test_internalServiceDeskImpl_Get(t *testing.T) {
 			name: "when the http call cannot be executed",
 			args: args{
 				ctx:           context.Background(),
-				serviceDeskID: 10001,
+				serviceDeskID: "10001",
 			},
 			on: func(fields *fields) {
 
@@ -227,7 +229,7 @@ func Test_internalServiceDeskImpl_Get(t *testing.T) {
 			name: "when the request cannot be created",
 			args: args{
 				ctx:           context.Background(),
-				serviceDeskID: 10001,
+				serviceDeskID: "10001",
 			},
 			on: func(fields *fields) {
 
@@ -305,7 +307,7 @@ func Test_internalServiceDeskImpl_Attach(t *testing.T) {
 
 	type args struct {
 		ctx           context.Context
-		serviceDeskID int
+		serviceDeskID string
 		fileName      string
 		file          io.Reader
 	}
@@ -322,7 +324,7 @@ func Test_internalServiceDeskImpl_Attach(t *testing.T) {
 			name: "when the parameters are correct",
 			args: args{
 				ctx:           context.Background(),
-				serviceDeskID: 10001,
+				serviceDeskID: "10001",
 				fileName:      "LICENSE",
 				file:          fileMocked,
 			},
@@ -351,7 +353,7 @@ func Test_internalServiceDeskImpl_Attach(t *testing.T) {
 			name: "when the http call cannot be executed",
 			args: args{
 				ctx:           context.Background(),
-				serviceDeskID: 10001,
+				serviceDeskID: "10001",
 				fileName:      "LICENSE",
 				file:          fileMocked,
 			},
@@ -382,7 +384,7 @@ func Test_internalServiceDeskImpl_Attach(t *testing.T) {
 			name: "when the request cannot be created",
 			args: args{
 				ctx:           context.Background(),
-				serviceDeskID: 10001,
+				serviceDeskID: "10001",
 				fileName:      "LICENSE",
 				file:          fileMocked,
 			},
@@ -417,7 +419,7 @@ func Test_internalServiceDeskImpl_Attach(t *testing.T) {
 			name: "when the file name is not provided",
 			args: args{
 				ctx:           context.Background(),
-				serviceDeskID: 10001,
+				serviceDeskID: "10001",
 			},
 			Err:     model.ErrNoFileNameError,
 			wantErr: true,
@@ -427,7 +429,7 @@ func Test_internalServiceDeskImpl_Attach(t *testing.T) {
 			name: "when the file reader is not provided",
 			args: args{
 				ctx:           context.Background(),
-				serviceDeskID: 10001,
+				serviceDeskID: "10001",
 				fileName:      "LICENSE",
 			},
 			Err:     model.ErrNoFileReaderError,

--- a/service/sm/service_desk.go
+++ b/service/sm/service_desk.go
@@ -2,8 +2,9 @@ package sm
 
 import (
 	"context"
-	model "github.com/ctreminiom/go-atlassian/pkg/infra/models"
 	"io"
+
+	model "github.com/ctreminiom/go-atlassian/pkg/infra/models"
 )
 
 type ServiceDeskConnector interface {
@@ -24,12 +25,12 @@ type ServiceDeskConnector interface {
 	// GET /rest/servicedeskapi/servicedesk/{serviceDeskId}
 	//
 	// https://docs.go-atlassian.io/jira-service-management-cloud/request/service-desk#get-service-desk-by-id
-	Get(ctx context.Context, serviceDeskID int) (*model.ServiceDeskScheme, *model.ResponseScheme, error)
+	Get(ctx context.Context, serviceDeskID string) (*model.ServiceDeskScheme, *model.ResponseScheme, error)
 
 	// Attach one temporary attachments to a service desk
 	//
 	// POST /rest/servicedeskapi/servicedesk/{serviceDeskId}/attachTemporaryFile
 	//
 	// https://docs.go-atlassian.io/jira-service-management-cloud/request/service-desk#attach-temporary-file
-	Attach(ctx context.Context, serviceDeskID int, fileName string, file io.Reader) (*model.ServiceDeskTemporaryFileScheme, *model.ResponseScheme, error)
+	Attach(ctx context.Context, serviceDeskID string, fileName string, file io.Reader) (*model.ServiceDeskTemporaryFileScheme, *model.ResponseScheme, error)
 }


### PR DESCRIPTION
Based on the official document those URLs wants a string for `serviceDeskID`.

https://developer.atlassian.com/cloud/jira/service-desk/rest/api-group-servicedesk/#api-rest-servicedeskapi-servicedesk-servicedeskid-attachtemporaryfile-post

This will be a breaking change.