### PR TITLE
Changed data type to match other docs and added missing fields

### DIFF
--- a/confluence/internal/page_impl_test.go
+++ b/confluence/internal/page_impl_test.go
@@ -4,13 +4,15 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	model "github.com/ctreminiom/go-atlassian/pkg/infra/models"
-	"github.com/ctreminiom/go-atlassian/service"
-	"github.com/ctreminiom/go-atlassian/service/mocks"
-	"github.com/stretchr/testify/assert"
 	"log"
 	"net/http"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	model "github.com/ctreminiom/go-atlassian/pkg/infra/models"
+	"github.com/ctreminiom/go-atlassian/service"
+	"github.com/ctreminiom/go-atlassian/service/mocks"
 )
 
 func Test_internalPageImpl_Get(t *testing.T) {
@@ -998,8 +1000,8 @@ func Test_internalPageImpl_Update(t *testing.T) {
 	}
 
 	mockedPayload := &model.PageUpdatePayloadScheme{
-		ID:      215646235,
-		SpaceID: 203718658,
+		ID:      "215646235",
+		SpaceID: "203718658",
 		Status:  "current",
 		Title:   "Page create title test",
 		Body: &model.PageBodyRepresentationScheme{

--- a/pkg/infra/models/confluence_page.go
+++ b/pkg/infra/models/confluence_page.go
@@ -73,10 +73,11 @@ type PageBodyScheme struct {
 
 // PageCreatePayloadScheme represents the payload for creating a page in Confluence.
 type PageCreatePayloadScheme struct {
-	SpaceID string                        `json:"spaceId,omitempty"` // The ID of the space of the page.
-	Status  string                        `json:"status,omitempty"`  // The status of the page.
-	Title   string                        `json:"title,omitempty"`   // The title of the page.
-	Body    *PageBodyRepresentationScheme `json:"body,omitempty"`    // The body of the page.
+	SpaceID  string                        `json:"spaceId,omitempty"`  // The ID of the space of the page.
+	Status   string                        `json:"status,omitempty"`   // The status of the page.
+	Title    string                        `json:"title,omitempty"`    // The title of the page.
+	ParentID string                        `json:"parentId,omitempty"` // The ID of the parent of the page.
+	Body     *PageBodyRepresentationScheme `json:"body,omitempty"`     // The body of the page.
 }
 
 // PageBodyRepresentationScheme represents a representation of a body in Confluence.
@@ -87,12 +88,14 @@ type PageBodyRepresentationScheme struct {
 
 // PageUpdatePayloadScheme represents the payload for updating a page in Confluence.
 type PageUpdatePayloadScheme struct {
-	ID      int                             `json:"id,omitempty"`      // The ID of the page.
-	Status  string                          `json:"status,omitempty"`  // The status of the page.
-	Title   string                          `json:"title,omitempty"`   // The title of the page.
-	SpaceID int                             `json:"spaceId,omitempty"` // The ID of the space of the page.
-	Body    *PageBodyRepresentationScheme   `json:"body,omitempty"`    // The body of the page.
-	Version *PageUpdatePayloadVersionScheme `json:"version,omitempty"` // The version of the page.
+	ID       string                          `json:"id,omitempty"`       // The ID of the page.
+	Status   string                          `json:"status,omitempty"`   // The status of the page.
+	Title    string                          `json:"title,omitempty"`    // The title of the page.
+	SpaceID  string                          `json:"spaceId,omitempty"`  // The ID of the space of the page.
+	ParentID string                          `json:"parentId,omitempty"` // The ID of the parent of the page.
+	OwnerID  string                          `json:"ownerId,omitempty"`  // The ID of the owner of the page.
+	Body     *PageBodyRepresentationScheme   `json:"body,omitempty"`     // The body of the page.
+	Version  *PageUpdatePayloadVersionScheme `json:"version,omitempty"`  // The version of the page.
 }
 
 // PageUpdatePayloadVersionScheme represents the version of the payload for updating a page in Confluence.


### PR DESCRIPTION
This pull request includes updates to the `pkg/infra/models/confluence_page.go` file to enhance the Confluence page model by adding new fields and changing data types. The most important changes involve adding `ParentID` and `OwnerID` fields and changing the data type of `ID` and `SpaceID` from `int` to `string`.

### Enhancements to Confluence page model:

* [`pkg/infra/models/confluence_page.go`](diffhunk://#diff-84a013dbada8ba18ef8d89eb0e5bddb22f56cea72bae4bf829b99934b7c75463R79): Added `ParentID` field to `PageCreatePayloadScheme` to store the ID of the parent page.
* [`pkg/infra/models/confluence_page.go`](diffhunk://#diff-84a013dbada8ba18ef8d89eb0e5bddb22f56cea72bae4bf829b99934b7c75463L90-R96): Changed the data type of `ID` and `SpaceID` from `int` to `string` in `PageUpdatePayloadScheme` for consistency and flexibility.
* [`pkg/infra/models/confluence_page.go`](diffhunk://#diff-84a013dbada8ba18ef8d89eb0e5bddb22f56cea72bae4bf829b99934b7c75463L90-R96): Added `ParentID` and `OwnerID` fields to `PageUpdatePayloadScheme` to store the IDs of the parent and owner of the page, respectively.

Related documentations:
- https://developer.atlassian.com/cloud/confluence/rest/v2/api-group-page/#api-pages-post
- https://developer.atlassian.com/cloud/confluence/rest/v2/api-group-page/#api-pages-id-put
