### PR TITLE
Fix Organization API From and To  request options. Swap Unix() with UnixMilli() 

### DIFF
--- a/admin/internal/organization_impl.go
+++ b/admin/internal/organization_impl.go
@@ -249,12 +249,12 @@ func (i *internalOrganizationImpl) Events(ctx context.Context, organizationID st
 	if options != nil {
 
 		if !options.To.IsZero() {
-			timeAsEpoch := int(options.To.Unix())
+			timeAsEpoch := int(options.To.UnixMilli())
 			params.Add("to", strconv.Itoa(timeAsEpoch))
 		}
 
 		if !options.From.IsZero() {
-			timeAsEpoch := int(options.From.Unix())
+			timeAsEpoch := int(options.From.UnixMilli())
 			params.Add("from", strconv.Itoa(timeAsEpoch))
 		}
 


### PR DESCRIPTION
Atlassian API wants Epoch in milliseconds

I noticed during the debug that requests to the API go with Unix timestamp in seconds but Atlassian API wants milliseconds.

Here is the reference to their API:
https://developer.atlassian.com/cloud/admin/organization/rest/api-group-events/#api-v1-orgs-orgid-events-get