### PR TITLE
use same version for coverage as tracked in repository

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.17
+          go-version-file: ./go.mod
 
       - name: Run coverage
         run: go test -race -coverprofile=coverage.out -covermode=atomic ./...


### PR DESCRIPTION
This pull request includes a change to the Go setup in the GitHub Actions workflow for code coverage. The most important change is:

* [`.github/workflows/coverage.yml`](diffhunk://#diff-a2115d277b5ca5a2f09a999e53440839cf332b94da177f3d1766334555b0f7c6L21-R21): Modified the Go setup to use the `go-version-file` from `./go.mod` instead of specifying a fixed Go version.