### PR TITLE
Fix add watcher invalid payload issue

### DIFF
--- a/jira/internal/watcher_impl.go
+++ b/jira/internal/watcher_impl.go
@@ -93,9 +93,9 @@ func (i *internalWatcherImpl) Add(ctx context.Context, issueKeyOrID string, acco
 
 	endpoint := fmt.Sprintf("rest/api/%v/issue/%v/watchers", i.version, issueKeyOrID)
 
-	var payload []byte // add self user
+	var payload string // add self user
 	if len(accountID) > 0 {
-		payload = []byte(accountID[0]) // add another user
+		payload = accountID[0] // add another user
 	}
 	request, err := i.c.NewRequest(ctx, http.MethodPost, endpoint, "", payload)
 	if err != nil {

--- a/jira/internal/watcher_impl_test.go
+++ b/jira/internal/watcher_impl_test.go
@@ -199,7 +199,7 @@ func Test_internalWatcherImpl_Add(t *testing.T) {
 					http.MethodPost,
 					"rest/api/3/issue/DUMMY-5/watchers",
 					"",
-					[]byte(nil)).
+					"").
 					Return(&http.Request{}, nil)
 
 				client.On("Call",
@@ -230,7 +230,7 @@ func Test_internalWatcherImpl_Add(t *testing.T) {
 					http.MethodPost,
 					"rest/api/3/issue/DUMMY-5/watchers",
 					"",
-					[]byte("someAccountID")).
+					"someAccountID").
 					Return(&http.Request{}, nil)
 
 				client.On("Call",
@@ -261,7 +261,7 @@ func Test_internalWatcherImpl_Add(t *testing.T) {
 					http.MethodPost,
 					"rest/api/2/issue/DUMMY-5/watchers",
 					"",
-					[]byte(nil),
+					"",
 				).
 					Return(&http.Request{}, nil)
 
@@ -293,7 +293,7 @@ func Test_internalWatcherImpl_Add(t *testing.T) {
 					http.MethodPost,
 					"rest/api/2/issue/DUMMY-5/watchers",
 					"",
-					[]byte("someAccountID")).
+					"someAccountID").
 					Return(&http.Request{}, nil)
 
 				client.On("Call",
@@ -335,7 +335,7 @@ func Test_internalWatcherImpl_Add(t *testing.T) {
 					http.MethodPost,
 					"rest/api/3/issue/DUMMY-5/watchers",
 					"",
-					[]byte(nil)).
+					"").
 					Return(&http.Request{}, errors.New("error, unable to create the http request"))
 
 				fields.c = client


### PR DESCRIPTION
Currently, when creating a Jira "Add Watcher" request, the username in playload has been converted from a `string` type to a `[]byte` type. This change causes the JSON-encoded result is not the username, leading to request failure. Here’s an example. https://go.dev/play/p/pBiwq2t2bNl

```golang
package main

import (
	"bytes"
	"encoding/json"
	"fmt"
)

func main() {
	accountID := "someuser"

	buf1 := new(bytes.Buffer)
	if err := json.NewEncoder(buf1).Encode(accountID); err != nil {
		panic(err)
	}
	fmt.Println(buf1)

	buf2 := new(bytes.Buffer)
	if err := json.NewEncoder(buf2).Encode([]byte(accountID)); err != nil {
		panic(err)
	}
	fmt.Println(buf2)
}
```

output

```
"someuser"

"c29tZXVzZXI="
```