### PR TITLE
Add fallback for datetime parsing as epoch timestamp for webhooks

### DIFF
--- a/pkg/infra/models/jira_time.go
+++ b/pkg/infra/models/jira_time.go
@@ -1,6 +1,10 @@
 package models
 
-import "time"
+import (
+	"fmt"
+	"strconv"
+	"time"
+)
 
 const (
 	// TimeFormat is the format for Jira type "date-time".
@@ -24,11 +28,17 @@ func (d *DateScheme) UnmarshalJSON(data []byte) error {
 	}
 
 	parsed, err := time.Parse(`"`+DateFormat+`"`, string(data))
-	if err != nil {
-		return err
+	if err == nil {
+		*d = DateScheme(parsed)
+		return nil
 	}
 
-	*d = DateScheme(parsed)
+	epoch, err := strconv.ParseInt(string(data), 10, 64)
+	if err != nil {
+		return fmt.Errorf("fallback to epoch: %w", err)
+	}
+
+	*d = DateScheme(time.Unix(epoch, 0))
 	return nil
 }
 
@@ -47,10 +57,16 @@ func (d *DateTimeScheme) UnmarshalJSON(data []byte) error {
 	}
 
 	parsed, err := time.Parse(`"`+TimeFormat+`"`, string(data))
-	if err != nil {
-		return err
+	if err == nil {
+		*d = DateTimeScheme(parsed)
+		return nil
 	}
 
-	*d = DateTimeScheme(parsed)
+	epoch, err := strconv.ParseInt(string(data), 10, 64)
+	if err != nil {
+		return fmt.Errorf("fallback to epoch: %w", err)
+	}
+
+	*d = DateTimeScheme(time.Unix(epoch, 0))
 	return nil
 }


### PR DESCRIPTION
Due to different datetime formats between Jira API and Webhooks send by Jira.
Problem asked in Jira community: https://community.atlassian.com/t5/Jira-questions/How-to-get-the-resolutiondate-in-a-consistent-format-webhook-API/qaq-p/2899334

`Issue data (Jira format)` from JIRA Automation: https://support.atlassian.com/cloud-automation/docs/issue-data-jira-format-payload-for-send-web-request-action/

TODOs:
- [ ] Tests
- [ ] Validate other webhook fields