### PR TITLE
Added new jql search and marked old functions as deprecated

### DIFF
--- a/jira/internal/search_impl_adf.go
+++ b/jira/internal/search_impl_adf.go
@@ -67,8 +67,8 @@ func (s *SearchADFService) ApproximateCount(ctx context.Context, jql string) (*m
 // BulkFetch fetches multiple issues by their IDs or keys
 //
 // POST /rest/api/3/issue/bulkfetch
-func (s *SearchADFService) BulkFetch(ctx context.Context, issueIdsOrKeys []string, fields []string) (*model.IssueBulkFetchScheme, *model.ResponseScheme, error) {
-	return s.internalClient.BulkFetch(ctx, issueIdsOrKeys, fields)
+func (s *SearchADFService) BulkFetch(ctx context.Context, issueIDsOrKeys []string, fields []string) (*model.IssueBulkFetchScheme, *model.ResponseScheme, error) {
+	return s.internalClient.BulkFetch(ctx, issueIDsOrKeys, fields)
 }
 
 type internalSearchADFImpl struct {
@@ -232,13 +232,13 @@ func (i *internalSearchADFImpl) ApproximateCount(ctx context.Context, jql string
 // BulkFetch fetches multiple issues by their IDs or keys
 //
 // POST /rest/api/3/issue/bulkfetch
-func (i *internalSearchADFImpl) BulkFetch(ctx context.Context, issueIdsOrKeys []string, fields []string) (*model.IssueBulkFetchScheme, *model.ResponseScheme, error) {
+func (i *internalSearchADFImpl) BulkFetch(ctx context.Context, issueIDsOrKeys []string, fields []string) (*model.IssueBulkFetchScheme, *model.ResponseScheme, error) {
 
 	payload := struct {
-		IssueIdsOrKeys []string `json:"issueIdsOrKeys,omitempty"`
+		IssueIDsOrKeys []string `json:"issueIdsOrKeys,omitempty"`
 		Fields         []string `json:"fields,omitempty"`
 	}{
-		IssueIdsOrKeys: issueIdsOrKeys,
+		IssueIDsOrKeys: issueIDsOrKeys,
 		Fields:         fields,
 	}
 

--- a/jira/internal/search_impl_adf.go
+++ b/jira/internal/search_impl_adf.go
@@ -3,13 +3,14 @@ package internal
 import (
 	"context"
 	"fmt"
-	model "github.com/ctreminiom/go-atlassian/v2/pkg/infra/models"
-	"github.com/ctreminiom/go-atlassian/v2/service"
-	"github.com/ctreminiom/go-atlassian/v2/service/jira"
 	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
+
+	model "github.com/ctreminiom/go-atlassian/v2/pkg/infra/models"
+	"github.com/ctreminiom/go-atlassian/v2/service"
+	"github.com/ctreminiom/go-atlassian/v2/service/jira"
 )
 
 // SearchADFService provides methods to manage advanced document format (ADF) searches in Jira Service Management.
@@ -32,6 +33,8 @@ func (s *SearchADFService) Checks(ctx context.Context, payload *model.IssueSearc
 // GET /rest/api/3/search
 //
 // https://docs.go-atlassian.io/jira-software-cloud/issues/search#search-for-issues-using-jql-get
+//
+// Deprecated: This endpoint will be removed after May 1, 2025. Use SearchJQL, BulkFetch and ApproximateCount instead.
 func (s *SearchADFService) Get(ctx context.Context, jql string, fields, expands []string, startAt, maxResults int, validate string) (*model.IssueSearchScheme, *model.ResponseScheme, error) {
 	return s.internalClient.Get(ctx, jql, fields, expands, startAt, maxResults, validate)
 }
@@ -41,8 +44,31 @@ func (s *SearchADFService) Get(ctx context.Context, jql string, fields, expands 
 // POST /rest/api/3/search
 //
 // https://docs.go-atlassian.io/jira-software-cloud/issues/search#search-for-issues-using-jql-get
+//
+// Deprecated: This endpoint will be removed after May 1, 2025. Use SearchJQL, BulkFetch and ApproximateCount instead.
 func (s *SearchADFService) Post(ctx context.Context, jql string, fields, expands []string, startAt, maxResults int, validate string) (*model.IssueSearchScheme, *model.ResponseScheme, error) {
 	return s.internalClient.Post(ctx, jql, fields, expands, startAt, maxResults, validate)
+}
+
+// SearchJQL searches issues using the new JQL search endpoint
+//
+// POST /rest/api/3/search/jql
+func (s *SearchADFService) SearchJQL(ctx context.Context, jql string, fields, expands []string, maxResults int, nextPageToken string) (*model.IssueSearchJQLScheme, *model.ResponseScheme, error) {
+	return s.internalClient.SearchJQL(ctx, jql, fields, expands, maxResults, nextPageToken)
+}
+
+// ApproximateCount gets an approximate count of issues matching a JQL query
+//
+// POST /rest/api/3/search/approximate-count
+func (s *SearchADFService) ApproximateCount(ctx context.Context, jql string) (*model.IssueSearchApproximateCountScheme, *model.ResponseScheme, error) {
+	return s.internalClient.ApproximateCount(ctx, jql)
+}
+
+// BulkFetch fetches multiple issues by their IDs or keys
+//
+// POST /rest/api/3/issue/bulkfetch
+func (s *SearchADFService) BulkFetch(ctx context.Context, issueIdsOrKeys []string, fields []string) (*model.IssueBulkFetchScheme, *model.ResponseScheme, error) {
+	return s.internalClient.BulkFetch(ctx, issueIdsOrKeys, fields)
 }
 
 type internalSearchADFImpl struct {
@@ -133,6 +159,97 @@ func (i *internalSearchADFImpl) Post(ctx context.Context, jql string, fields, ex
 	}
 
 	issues := new(model.IssueSearchScheme)
+	response, err := i.c.Call(request, issues)
+	if err != nil {
+		return nil, response, err
+	}
+
+	return issues, response, nil
+}
+
+// SearchJQL searches issues using the new JQL search endpoint
+//
+// POST /rest/api/3/search/jql
+func (i *internalSearchADFImpl) SearchJQL(ctx context.Context, jql string, fields, expands []string, maxResults int, nextPageToken string) (*model.IssueSearchJQLScheme, *model.ResponseScheme, error) {
+
+	payload := struct {
+		Jql           string   `json:"jql,omitempty"`
+		MaxResults    int      `json:"maxResults,omitempty"`
+		Fields        []string `json:"fields,omitempty"`
+		Expand        []string `json:"expand,omitempty"`
+		NextPageToken string   `json:"nextPageToken,omitempty"`
+	}{
+		Jql:           jql,
+		MaxResults:    maxResults,
+		Fields:        fields,
+		Expand:        expands,
+		NextPageToken: nextPageToken,
+	}
+
+	endpoint := fmt.Sprintf("rest/api/%v/search/jql", i.version)
+
+	request, err := i.c.NewRequest(ctx, http.MethodPost, endpoint, "", payload)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	issues := new(model.IssueSearchJQLScheme)
+	response, err := i.c.Call(request, issues)
+	if err != nil {
+		return nil, response, err
+	}
+
+	return issues, response, nil
+}
+
+// ApproximateCount gets an approximate count of issues matching a JQL query
+//
+// POST /rest/api/3/search/approximate-count
+func (i *internalSearchADFImpl) ApproximateCount(ctx context.Context, jql string) (*model.IssueSearchApproximateCountScheme, *model.ResponseScheme, error) {
+
+	payload := struct {
+		Jql string `json:"jql,omitempty"`
+	}{
+		Jql: jql,
+	}
+
+	endpoint := fmt.Sprintf("rest/api/%v/search/approximate-count", i.version)
+
+	request, err := i.c.NewRequest(ctx, http.MethodPost, endpoint, "", payload)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	count := new(model.IssueSearchApproximateCountScheme)
+	response, err := i.c.Call(request, count)
+	if err != nil {
+		return nil, response, err
+	}
+
+	return count, response, nil
+}
+
+// BulkFetch fetches multiple issues by their IDs or keys
+//
+// POST /rest/api/3/issue/bulkfetch
+func (i *internalSearchADFImpl) BulkFetch(ctx context.Context, issueIdsOrKeys []string, fields []string) (*model.IssueBulkFetchScheme, *model.ResponseScheme, error) {
+
+	payload := struct {
+		IssueIdsOrKeys []string `json:"issueIdsOrKeys,omitempty"`
+		Fields         []string `json:"fields,omitempty"`
+	}{
+		IssueIdsOrKeys: issueIdsOrKeys,
+		Fields:         fields,
+	}
+
+	endpoint := fmt.Sprintf("rest/api/%v/issue/bulkfetch", i.version)
+
+	request, err := i.c.NewRequest(ctx, http.MethodPost, endpoint, "", payload)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	issues := new(model.IssueBulkFetchScheme)
 	response, err := i.c.Call(request, issues)
 	if err != nil {
 		return nil, response, err

--- a/jira/internal/search_impl_rich_text.go
+++ b/jira/internal/search_impl_rich_text.go
@@ -67,8 +67,8 @@ func (s *SearchRichTextService) ApproximateCount(ctx context.Context, jql string
 // BulkFetch fetches multiple issues by their IDs or keys
 //
 // POST /rest/api/2/issue/bulkfetch
-func (s *SearchRichTextService) BulkFetch(ctx context.Context, issueIdsOrKeys []string, fields []string) (*model.IssueBulkFetchSchemeV2, *model.ResponseScheme, error) {
-	return s.internalClient.BulkFetch(ctx, issueIdsOrKeys, fields)
+func (s *SearchRichTextService) BulkFetch(ctx context.Context, issueIDsOrKeys []string, fields []string) (*model.IssueBulkFetchSchemeV2, *model.ResponseScheme, error) {
+	return s.internalClient.BulkFetch(ctx, issueIDsOrKeys, fields)
 }
 
 type internalSearchRichTextImpl struct {
@@ -232,13 +232,13 @@ func (i *internalSearchRichTextImpl) ApproximateCount(ctx context.Context, jql s
 // BulkFetch fetches multiple issues by their IDs or keys
 //
 // POST /rest/api/2/issue/bulkfetch
-func (i *internalSearchRichTextImpl) BulkFetch(ctx context.Context, issueIdsOrKeys []string, fields []string) (*model.IssueBulkFetchSchemeV2, *model.ResponseScheme, error) {
+func (i *internalSearchRichTextImpl) BulkFetch(ctx context.Context, issueIDsOrKeys []string, fields []string) (*model.IssueBulkFetchSchemeV2, *model.ResponseScheme, error) {
 
 	payload := struct {
-		IssueIdsOrKeys []string `json:"issueIdsOrKeys,omitempty"`
+		IssueIDsOrKeys []string `json:"issueIdsOrKeys,omitempty"`
 		Fields         []string `json:"fields,omitempty"`
 	}{
-		IssueIdsOrKeys: issueIdsOrKeys,
+		IssueIDsOrKeys: issueIDsOrKeys,
 		Fields:         fields,
 	}
 

--- a/jira/internal/search_impl_rich_text.go
+++ b/jira/internal/search_impl_rich_text.go
@@ -3,13 +3,14 @@ package internal
 import (
 	"context"
 	"fmt"
-	model "github.com/ctreminiom/go-atlassian/v2/pkg/infra/models"
-	"github.com/ctreminiom/go-atlassian/v2/service"
-	"github.com/ctreminiom/go-atlassian/v2/service/jira"
 	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
+
+	model "github.com/ctreminiom/go-atlassian/v2/pkg/infra/models"
+	"github.com/ctreminiom/go-atlassian/v2/service"
+	"github.com/ctreminiom/go-atlassian/v2/service/jira"
 )
 
 // SearchRichTextService provides methods to manage rich text searches in Jira Service Management.
@@ -32,6 +33,8 @@ func (s *SearchRichTextService) Checks(ctx context.Context, payload *model.Issue
 // GET /rest/api/2/search
 //
 // https://docs.go-atlassian.io/jira-software-cloud/issues/search#search-for-issues-using-jql-get
+//
+// Deprecated: This endpoint will be removed after May 1, 2025. Use SearchJQL, BulkFetch and ApproximateCount instead.
 func (s *SearchRichTextService) Get(ctx context.Context, jql string, fields, expands []string, startAt, maxResults int, validate string) (*model.IssueSearchSchemeV2, *model.ResponseScheme, error) {
 	return s.internalClient.Get(ctx, jql, fields, expands, startAt, maxResults, validate)
 }
@@ -41,8 +44,31 @@ func (s *SearchRichTextService) Get(ctx context.Context, jql string, fields, exp
 // POST /rest/api/2/search
 //
 // https://docs.go-atlassian.io/jira-software-cloud/issues/search#search-for-issues-using-jql-get
+//
+// Deprecated: This endpoint will be removed after May 1, 2025. Use SearchJQL, BulkFetch and ApproximateCount instead.
 func (s *SearchRichTextService) Post(ctx context.Context, jql string, fields, expands []string, startAt, maxResults int, validate string) (*model.IssueSearchSchemeV2, *model.ResponseScheme, error) {
 	return s.internalClient.Post(ctx, jql, fields, expands, startAt, maxResults, validate)
+}
+
+// SearchJQL searches issues using the new JQL search endpoint
+//
+// POST /rest/api/2/search/jql
+func (s *SearchRichTextService) SearchJQL(ctx context.Context, jql string, fields, expands []string, maxResults int, nextPageToken string) (*model.IssueSearchJQLSchemeV2, *model.ResponseScheme, error) {
+	return s.internalClient.SearchJQL(ctx, jql, fields, expands, maxResults, nextPageToken)
+}
+
+// ApproximateCount gets an approximate count of issues matching a JQL query
+//
+// POST /rest/api/2/search/approximate-count
+func (s *SearchRichTextService) ApproximateCount(ctx context.Context, jql string) (*model.IssueSearchApproximateCountScheme, *model.ResponseScheme, error) {
+	return s.internalClient.ApproximateCount(ctx, jql)
+}
+
+// BulkFetch fetches multiple issues by their IDs or keys
+//
+// POST /rest/api/2/issue/bulkfetch
+func (s *SearchRichTextService) BulkFetch(ctx context.Context, issueIdsOrKeys []string, fields []string) (*model.IssueBulkFetchSchemeV2, *model.ResponseScheme, error) {
+	return s.internalClient.BulkFetch(ctx, issueIdsOrKeys, fields)
 }
 
 type internalSearchRichTextImpl struct {
@@ -133,6 +159,97 @@ func (i *internalSearchRichTextImpl) Post(ctx context.Context, jql string, field
 	}
 
 	issues := new(model.IssueSearchSchemeV2)
+	response, err := i.c.Call(request, issues)
+	if err != nil {
+		return nil, response, err
+	}
+
+	return issues, response, nil
+}
+
+// SearchJQL searches issues using the new JQL search endpoint
+//
+// POST /rest/api/2/search/jql
+func (i *internalSearchRichTextImpl) SearchJQL(ctx context.Context, jql string, fields, expands []string, maxResults int, nextPageToken string) (*model.IssueSearchJQLSchemeV2, *model.ResponseScheme, error) {
+
+	payload := struct {
+		Jql           string   `json:"jql,omitempty"`
+		MaxResults    int      `json:"maxResults,omitempty"`
+		Fields        []string `json:"fields,omitempty"`
+		Expand        []string `json:"expand,omitempty"`
+		NextPageToken string   `json:"nextPageToken,omitempty"`
+	}{
+		Jql:           jql,
+		MaxResults:    maxResults,
+		Fields:        fields,
+		Expand:        expands,
+		NextPageToken: nextPageToken,
+	}
+
+	endpoint := fmt.Sprintf("rest/api/%v/search/jql", i.version)
+
+	request, err := i.c.NewRequest(ctx, http.MethodPost, endpoint, "", payload)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	issues := new(model.IssueSearchJQLSchemeV2)
+	response, err := i.c.Call(request, issues)
+	if err != nil {
+		return nil, response, err
+	}
+
+	return issues, response, nil
+}
+
+// ApproximateCount gets an approximate count of issues matching a JQL query
+//
+// POST /rest/api/2/search/approximate-count
+func (i *internalSearchRichTextImpl) ApproximateCount(ctx context.Context, jql string) (*model.IssueSearchApproximateCountScheme, *model.ResponseScheme, error) {
+
+	payload := struct {
+		Jql string `json:"jql,omitempty"`
+	}{
+		Jql: jql,
+	}
+
+	endpoint := fmt.Sprintf("rest/api/%v/search/approximate-count", i.version)
+
+	request, err := i.c.NewRequest(ctx, http.MethodPost, endpoint, "", payload)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	count := new(model.IssueSearchApproximateCountScheme)
+	response, err := i.c.Call(request, count)
+	if err != nil {
+		return nil, response, err
+	}
+
+	return count, response, nil
+}
+
+// BulkFetch fetches multiple issues by their IDs or keys
+//
+// POST /rest/api/2/issue/bulkfetch
+func (i *internalSearchRichTextImpl) BulkFetch(ctx context.Context, issueIdsOrKeys []string, fields []string) (*model.IssueBulkFetchSchemeV2, *model.ResponseScheme, error) {
+
+	payload := struct {
+		IssueIdsOrKeys []string `json:"issueIdsOrKeys,omitempty"`
+		Fields         []string `json:"fields,omitempty"`
+	}{
+		IssueIdsOrKeys: issueIdsOrKeys,
+		Fields:         fields,
+	}
+
+	endpoint := fmt.Sprintf("rest/api/%v/issue/bulkfetch", i.version)
+
+	request, err := i.c.NewRequest(ctx, http.MethodPost, endpoint, "", payload)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	issues := new(model.IssueBulkFetchSchemeV2)
 	response, err := i.c.Call(request, issues)
 	if err != nil {
 		return nil, response, err

--- a/jira/internal/search_impl_rich_text_test.go
+++ b/jira/internal/search_impl_rich_text_test.go
@@ -470,3 +470,409 @@ func Test_internalSearchRichTextImpl_Get(t *testing.T) {
 		})
 	}
 }
+
+func Test_internalSearchRichTextImpl_SearchJQL(t *testing.T) {
+
+	type fields struct {
+		c       service.Connector
+		version string
+	}
+
+	type args struct {
+		ctx           context.Context
+		jql           string
+		fields        []string
+		expands       []string
+		maxResults    int
+		nextPageToken string
+	}
+
+	testCases := []struct {
+		name    string
+		fields  fields
+		args    args
+		on      func(*fields)
+		wantErr bool
+		Err     error
+	}{
+		{
+			name:   "when the search jql operation is successful",
+			fields: fields{version: "2"},
+			args: args{
+				ctx:           context.Background(),
+				jql:           "project = FOO",
+				fields:        []string{"summary", "status"},
+				expands:       []string{"changelog", "names"},
+				maxResults:    50,
+				nextPageToken: "CAEaAggD",
+			},
+			on: func(fields *fields) {
+
+				client := mocks.NewConnector(t)
+
+				payload := struct {
+					Jql           string   `json:"jql,omitempty"`
+					MaxResults    int      `json:"maxResults,omitempty"`
+					Fields        []string `json:"fields,omitempty"`
+					Expand        []string `json:"expand,omitempty"`
+					NextPageToken string   `json:"nextPageToken,omitempty"`
+				}{
+					Jql:           "project = FOO",
+					MaxResults:    50,
+					Fields:        []string{"summary", "status"},
+					Expand:        []string{"changelog", "names"},
+					NextPageToken: "CAEaAggD",
+				}
+
+				client.On("NewRequest",
+					context.Background(),
+					http.MethodPost,
+					"rest/api/2/search/jql",
+					"", payload).
+					Return(&http.Request{}, nil)
+
+				client.On("Call",
+					&http.Request{},
+					&model.IssueSearchJQLSchemeV2{}).
+					Return(&model.ResponseScheme{}, nil)
+
+				fields.c = client
+			},
+			wantErr: false,
+			Err:     nil,
+		},
+
+		{
+			name:   "when the request returns an error",
+			fields: fields{version: "2"},
+			args: args{
+				ctx:           context.Background(),
+				jql:           "project = FOO",
+				fields:        []string{"summary", "status"},
+				expands:       []string{"changelog", "names"},
+				maxResults:    50,
+				nextPageToken: "CAEaAggD",
+			},
+			on: func(fields *fields) {
+
+				client := mocks.NewConnector(t)
+
+				payload := struct {
+					Jql           string   `json:"jql,omitempty"`
+					MaxResults    int      `json:"maxResults,omitempty"`
+					Fields        []string `json:"fields,omitempty"`
+					Expand        []string `json:"expand,omitempty"`
+					NextPageToken string   `json:"nextPageToken,omitempty"`
+				}{
+					Jql:           "project = FOO",
+					MaxResults:    50,
+					Fields:        []string{"summary", "status"},
+					Expand:        []string{"changelog", "names"},
+					NextPageToken: "CAEaAggD",
+				}
+
+				client.On("NewRequest",
+					context.Background(),
+					http.MethodPost,
+					"rest/api/2/search/jql",
+					"", payload).
+					Return(&http.Request{}, errors.New("error"))
+
+				fields.c = client
+			},
+			wantErr: true,
+			Err:     errors.New("error"),
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+
+			if testCase.on != nil {
+				testCase.on(&testCase.fields)
+			}
+
+			searchImpl := &internalSearchRichTextImpl{
+				c:       testCase.fields.c,
+				version: testCase.fields.version,
+			}
+
+			gotResult, gotResponse, err := searchImpl.SearchJQL(
+				testCase.args.ctx,
+				testCase.args.jql,
+				testCase.args.fields,
+				testCase.args.expands,
+				testCase.args.maxResults,
+				testCase.args.nextPageToken,
+			)
+
+			if testCase.wantErr {
+
+				if err != nil {
+					t.Logf("error returned: %v", err.Error())
+				}
+
+				assert.Error(t, err)
+				assert.EqualError(t, err, testCase.Err.Error())
+
+			} else {
+
+				assert.NoError(t, err)
+				assert.NotEqual(t, gotResponse, nil)
+				assert.NotEqual(t, gotResult, nil)
+			}
+		})
+	}
+}
+
+func Test_internalSearchRichTextImpl_ApproximateCount(t *testing.T) {
+
+	type fields struct {
+		c       service.Connector
+		version string
+	}
+
+	type args struct {
+		ctx context.Context
+		jql string
+	}
+
+	testCases := []struct {
+		name    string
+		fields  fields
+		args    args
+		on      func(*fields)
+		wantErr bool
+		Err     error
+	}{
+		{
+			name:   "when the approximate count operation is successful",
+			fields: fields{version: "2"},
+			args: args{
+				ctx: context.Background(),
+				jql: "project = FOO",
+			},
+			on: func(fields *fields) {
+
+				client := mocks.NewConnector(t)
+
+				payload := struct {
+					Jql string `json:"jql,omitempty"`
+				}{
+					Jql: "project = FOO",
+				}
+
+				client.On("NewRequest",
+					context.Background(),
+					http.MethodPost,
+					"rest/api/2/search/approximate-count",
+					"", payload).
+					Return(&http.Request{}, nil)
+
+				client.On("Call",
+					&http.Request{},
+					&model.IssueSearchApproximateCountScheme{}).
+					Return(&model.ResponseScheme{}, nil)
+
+				fields.c = client
+			},
+			wantErr: false,
+			Err:     nil,
+		},
+
+		{
+			name:   "when the request returns an error",
+			fields: fields{version: "2"},
+			args: args{
+				ctx: context.Background(),
+				jql: "project = FOO",
+			},
+			on: func(fields *fields) {
+
+				client := mocks.NewConnector(t)
+
+				payload := struct {
+					Jql string `json:"jql,omitempty"`
+				}{
+					Jql: "project = FOO",
+				}
+
+				client.On("NewRequest",
+					context.Background(),
+					http.MethodPost,
+					"rest/api/2/search/approximate-count",
+					"", payload).
+					Return(&http.Request{}, errors.New("error"))
+
+				fields.c = client
+			},
+			wantErr: true,
+			Err:     errors.New("error"),
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+
+			if testCase.on != nil {
+				testCase.on(&testCase.fields)
+			}
+
+			searchImpl := &internalSearchRichTextImpl{
+				c:       testCase.fields.c,
+				version: testCase.fields.version,
+			}
+
+			gotResult, gotResponse, err := searchImpl.ApproximateCount(
+				testCase.args.ctx,
+				testCase.args.jql,
+			)
+
+			if testCase.wantErr {
+
+				if err != nil {
+					t.Logf("error returned: %v", err.Error())
+				}
+
+				assert.Error(t, err)
+				assert.EqualError(t, err, testCase.Err.Error())
+
+			} else {
+
+				assert.NoError(t, err)
+				assert.NotEqual(t, gotResponse, nil)
+				assert.NotEqual(t, gotResult, nil)
+			}
+		})
+	}
+}
+
+func Test_internalSearchRichTextImpl_BulkFetch(t *testing.T) {
+
+	type fields struct {
+		c       service.Connector
+		version string
+	}
+
+	type args struct {
+		ctx            context.Context
+		issueIDsOrKeys []string
+		fields         []string
+	}
+
+	testCases := []struct {
+		name    string
+		fields  fields
+		args    args
+		on      func(*fields)
+		wantErr bool
+		Err     error
+	}{
+		{
+			name:   "when the bulk fetch operation is successful",
+			fields: fields{version: "2"},
+			args: args{
+				ctx:            context.Background(),
+				issueIDsOrKeys: []string{"FOO-1", "10067", "BAR-1"},
+				fields:         []string{"summary", "status", "priority"},
+			},
+			on: func(fields *fields) {
+
+				client := mocks.NewConnector(t)
+
+				payload := struct {
+					IssueIDsOrKeys []string `json:"issueIdsOrKeys,omitempty"`
+					Fields         []string `json:"fields,omitempty"`
+				}{
+					IssueIDsOrKeys: []string{"FOO-1", "10067", "BAR-1"},
+					Fields:         []string{"summary", "status", "priority"},
+				}
+
+				client.On("NewRequest",
+					context.Background(),
+					http.MethodPost,
+					"rest/api/2/issue/bulkfetch",
+					"", payload).
+					Return(&http.Request{}, nil)
+
+				client.On("Call",
+					&http.Request{},
+					&model.IssueBulkFetchSchemeV2{}).
+					Return(&model.ResponseScheme{}, nil)
+
+				fields.c = client
+			},
+			wantErr: false,
+			Err:     nil,
+		},
+
+		{
+			name:   "when the request returns an error",
+			fields: fields{version: "2"},
+			args: args{
+				ctx:            context.Background(),
+				issueIDsOrKeys: []string{"FOO-1", "10067", "BAR-1"},
+				fields:         []string{"summary", "status", "priority"},
+			},
+			on: func(fields *fields) {
+
+				client := mocks.NewConnector(t)
+
+				payload := struct {
+					IssueIDsOrKeys []string `json:"issueIdsOrKeys,omitempty"`
+					Fields         []string `json:"fields,omitempty"`
+				}{
+					IssueIDsOrKeys: []string{"FOO-1", "10067", "BAR-1"},
+					Fields:         []string{"summary", "status", "priority"},
+				}
+
+				client.On("NewRequest",
+					context.Background(),
+					http.MethodPost,
+					"rest/api/2/issue/bulkfetch",
+					"", payload).
+					Return(&http.Request{}, errors.New("error"))
+
+				fields.c = client
+			},
+			wantErr: true,
+			Err:     errors.New("error"),
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+
+			if testCase.on != nil {
+				testCase.on(&testCase.fields)
+			}
+
+			searchImpl := &internalSearchRichTextImpl{
+				c:       testCase.fields.c,
+				version: testCase.fields.version,
+			}
+
+			gotResult, gotResponse, err := searchImpl.BulkFetch(
+				testCase.args.ctx,
+				testCase.args.issueIDsOrKeys,
+				testCase.args.fields,
+			)
+
+			if testCase.wantErr {
+
+				if err != nil {
+					t.Logf("error returned: %v", err.Error())
+				}
+
+				assert.Error(t, err)
+				assert.EqualError(t, err, testCase.Err.Error())
+
+			} else {
+
+				assert.NoError(t, err)
+				assert.NotEqual(t, gotResponse, nil)
+				assert.NotEqual(t, gotResult, nil)
+			}
+		})
+	}
+}

--- a/pkg/infra/models/jira_search_count.go
+++ b/pkg/infra/models/jira_search_count.go
@@ -1,0 +1,6 @@
+package models
+
+// IssueSearchApproximateCountScheme represents the response from the approximate count endpoint
+type IssueSearchApproximateCountScheme struct {
+	Count int `json:"count,omitempty"`
+}

--- a/pkg/infra/models/jira_search_v2.go
+++ b/pkg/infra/models/jira_search_v2.go
@@ -9,3 +9,19 @@ type IssueSearchSchemeV2 struct {
 	Issues          []*IssueSchemeV2 `json:"issues,omitempty"`          // The issues returned in the results.
 	WarningMessages []string         `json:"warningMessages,omitempty"` // Any warning messages generated during the search.
 }
+
+// IssueSearchJQLSchemeV2 represents the response from the new JQL search endpoint for richtext (v2 API)
+type IssueSearchJQLSchemeV2 struct {
+	StartAt       int               `json:"startAt,omitempty"`
+	MaxResults    int               `json:"maxResults,omitempty"`
+	Total         int               `json:"total,omitempty"`
+	Issues        []*IssueSchemeV2  `json:"issues,omitempty"`
+	Names         map[string]string `json:"names,omitempty"`
+	Schema        map[string]string `json:"schema,omitempty"`
+	NextPageToken string            `json:"nextPageToken,omitempty"`
+}
+
+// IssueBulkFetchSchemeV2 represents the response from the bulk fetch endpoint for richtext (v2 API)
+type IssueBulkFetchSchemeV2 struct {
+	Issues []*IssueSchemeV2 `json:"issues,omitempty"`
+}

--- a/pkg/infra/models/jira_search_v3.go
+++ b/pkg/infra/models/jira_search_v3.go
@@ -15,3 +15,19 @@ type IssueTransitionsScheme struct {
 	Expand      string                   `json:"expand,omitempty"`      // The fields that are expanded in the results.
 	Transitions []*IssueTransitionScheme `json:"transitions,omitempty"` // The transitions of the issue.
 }
+
+// IssueSearchJQLScheme represents the response from the new JQL search endpoint for ADF (v3 API)
+type IssueSearchJQLScheme struct {
+	StartAt       int               `json:"startAt,omitempty"`
+	MaxResults    int               `json:"maxResults,omitempty"`
+	Total         int               `json:"total,omitempty"`
+	Issues        []*IssueScheme    `json:"issues,omitempty"`
+	Names         map[string]string `json:"names,omitempty"`
+	Schema        map[string]string `json:"schema,omitempty"`
+	NextPageToken string            `json:"nextPageToken,omitempty"`
+}
+
+// IssueBulkFetchScheme represents the response from the bulk fetch endpoint for ADF (v3 API)
+type IssueBulkFetchScheme struct {
+	Issues []*IssueScheme `json:"issues,omitempty"`
+}

--- a/service/jira/search.go
+++ b/service/jira/search.go
@@ -1,4 +1,3 @@
-// filepath: c:\Users\info\repo\go-atlassian\service\jira\search.go
 package jira
 
 import (

--- a/service/jira/search.go
+++ b/service/jira/search.go
@@ -53,7 +53,7 @@ type SearchRichTextConnector interface {
 	//
 	// POST /rest/api/2/issue/bulkfetch
 	//
-	BulkFetch(ctx context.Context, issueIdsOrKeys []string, fields []string) (*model.IssueBulkFetchSchemeV2, *model.ResponseScheme, error)
+	BulkFetch(ctx context.Context, issueIDsOrKeys []string, fields []string) (*model.IssueBulkFetchSchemeV2, *model.ResponseScheme, error)
 }
 
 type SearchADFConnector interface {
@@ -93,5 +93,5 @@ type SearchADFConnector interface {
 	//
 	// POST /rest/api/3/issue/bulkfetch
 	//
-	BulkFetch(ctx context.Context, issueIdsOrKeys []string, fields []string) (*model.IssueBulkFetchScheme, *model.ResponseScheme, error)
+	BulkFetch(ctx context.Context, issueIDsOrKeys []string, fields []string) (*model.IssueBulkFetchScheme, *model.ResponseScheme, error)
 }

--- a/service/jira/search.go
+++ b/service/jira/search.go
@@ -1,7 +1,9 @@
+// filepath: c:\Users\info\repo\go-atlassian\service\jira\search.go
 package jira
 
 import (
 	"context"
+
 	model "github.com/ctreminiom/go-atlassian/v2/pkg/infra/models"
 )
 
@@ -23,6 +25,8 @@ type SearchRichTextConnector interface {
 	// GET /rest/api/2/search
 	//
 	// https://docs.go-atlassian.io/jira-software-cloud/issues/search#search-for-issues-using-jql-get
+	//
+	// Deprecated: This endpoint will be removed after May 1, 2025. Use SearchJQL, BulkFetch and ApproximateCount instead.
 	Get(ctx context.Context, jql string, fields, expands []string, startAt, maxResults int, validate string) (*model.IssueSearchSchemeV2, *model.ResponseScheme, error)
 
 	// Post search issues using JQL query under the HTTP Method POST
@@ -30,7 +34,27 @@ type SearchRichTextConnector interface {
 	// POST /rest/api/2/search
 	//
 	// https://docs.go-atlassian.io/jira-software-cloud/issues/search#search-for-issues-using-jql-get
+	//
+	// Deprecated: This endpoint will be removed after May 1, 2025. Use SearchJQL, BulkFetch and ApproximateCount instead.
 	Post(ctx context.Context, jql string, fields, expands []string, startAt, maxResults int, validate string) (*model.IssueSearchSchemeV2, *model.ResponseScheme, error)
+
+	// SearchJQL search issues using the new JQL search endpoint
+	//
+	// POST /rest/api/2/search/jql
+	//
+	SearchJQL(ctx context.Context, jql string, fields, expands []string, maxResults int, nextPageToken string) (*model.IssueSearchJQLSchemeV2, *model.ResponseScheme, error)
+
+	// ApproximateCount gets an approximate count of issues matching a JQL query
+	//
+	// POST /rest/api/2/search/approximate-count
+	//
+	ApproximateCount(ctx context.Context, jql string) (*model.IssueSearchApproximateCountScheme, *model.ResponseScheme, error)
+
+	// BulkFetch fetches multiple issues by their IDs or keys
+	//
+	// POST /rest/api/2/issue/bulkfetch
+	//
+	BulkFetch(ctx context.Context, issueIdsOrKeys []string, fields []string) (*model.IssueBulkFetchSchemeV2, *model.ResponseScheme, error)
 }
 
 type SearchADFConnector interface {
@@ -41,6 +65,8 @@ type SearchADFConnector interface {
 	// GET /rest/api/3/search
 	//
 	// https://docs.go-atlassian.io/jira-software-cloud/issues/search#search-for-issues-using-jql-get
+	//
+	// Deprecated: This endpoint will be removed after May 1, 2025. Use SearchJQL, BulkFetch and ApproximateCount instead.
 	Get(ctx context.Context, jql string, fields, expands []string, startAt, maxResults int, validate string) (*model.IssueSearchScheme, *model.ResponseScheme, error)
 
 	// Post search issues using JQL query under the HTTP Method POST
@@ -48,5 +74,25 @@ type SearchADFConnector interface {
 	// POST /rest/api/3/search
 	//
 	// https://docs.go-atlassian.io/jira-software-cloud/issues/search#search-for-issues-using-jql-get
+	//
+	// Deprecated: This endpoint will be removed after May 1, 2025. Use SearchJQL, BulkFetch and ApproximateCount instead.
 	Post(ctx context.Context, jql string, fields, expands []string, startAt, maxResults int, validate string) (*model.IssueSearchScheme, *model.ResponseScheme, error)
+
+	// SearchJQL searches issues using the new JQL search endpoint
+	//
+	// POST /rest/api/3/search/jql
+	//
+	SearchJQL(ctx context.Context, jql string, fields, expands []string, maxResults int, nextPageToken string) (*model.IssueSearchJQLScheme, *model.ResponseScheme, error)
+
+	// ApproximateCount gets an approximate count of issues matching a JQL query
+	//
+	// POST /rest/api/3/search/approximate-count
+	//
+	ApproximateCount(ctx context.Context, jql string) (*model.IssueSearchApproximateCountScheme, *model.ResponseScheme, error)
+
+	// BulkFetch fetches multiple issues by their IDs or keys
+	//
+	// POST /rest/api/3/issue/bulkfetch
+	//
+	BulkFetch(ctx context.Context, issueIdsOrKeys []string, fields []string) (*model.IssueBulkFetchScheme, *model.ResponseScheme, error)
 }


### PR DESCRIPTION
This pull request introduces significant updates to the Jira search services by deprecating older endpoints and adding support for newer ones, including JQL-based search, approximate issue count, and bulk issue fetching. The changes also include updates to the internal implementations and data models to support these new functionalities.

### Deprecation and New Endpoint Additions:

* **Deprecation of Legacy Endpoints**: Marked the `Get` and `Post` methods in both `SearchADFService` and `SearchRichTextService` as deprecated, with a note that these will be removed after May 1, 2025. Users are encouraged to use the new `SearchJQL`, `BulkFetch`, and `ApproximateCount` methods instead. (`jira/internal/search_impl_adf.go`: [[1]](diffhunk://#diff-5bf058e6cede7f34d445fa1d2c4b6ef232123e7db2798c6b5422cf5a985df330R36-R37) [[2]](diffhunk://#diff-5bf058e6cede7f34d445fa1d2c4b6ef232123e7db2798c6b5422cf5a985df330R47-R73); `jira/internal/search_impl_rich_text.go`: [[3]](diffhunk://#diff-81689f98aedf8d01fd6b56bebdab18325c45c45569c4a7a105938a2197faf2f9R36-R37) [[4]](diffhunk://#diff-81689f98aedf8d01fd6b56bebdab18325c45c45569c4a7a105938a2197faf2f9R47-R73); `service/jira/search.go`: [[5]](diffhunk://#diff-9f534f67580f2d0ce83f68253c6fb8f6597e42d12955269669ee8c74fac052f2R28-R57) [[6]](diffhunk://#diff-9f534f67580f2d0ce83f68253c6fb8f6597e42d12955269669ee8c74fac052f2R68-R97)

* **New JQL-Based Search Methods**: Added `SearchJQL` methods to both `SearchADFService` and `SearchRichTextService` for querying issues using the new JQL endpoint. (`jira/internal/search_impl_adf.go`: [[1]](diffhunk://#diff-5bf058e6cede7f34d445fa1d2c4b6ef232123e7db2798c6b5422cf5a985df330R47-R73) [[2]](diffhunk://#diff-5bf058e6cede7f34d445fa1d2c4b6ef232123e7db2798c6b5422cf5a985df330R169-R259); `jira/internal/search_impl_rich_text.go`: [[3]](diffhunk://#diff-81689f98aedf8d01fd6b56bebdab18325c45c45569c4a7a105938a2197faf2f9R47-R73) [[4]](diffhunk://#diff-81689f98aedf8d01fd6b56bebdab18325c45c45569c4a7a105938a2197faf2f9R169-R259)

* **Approximate Count and Bulk Fetch**: Introduced `ApproximateCount` and `BulkFetch` methods to retrieve approximate issue counts and fetch multiple issues by their IDs or keys. These methods are available in both ADF and Rich Text services. (`jira/internal/search_impl_adf.go`: [[1]](diffhunk://#diff-5bf058e6cede7f34d445fa1d2c4b6ef232123e7db2798c6b5422cf5a985df330R47-R73) [[2]](diffhunk://#diff-5bf058e6cede7f34d445fa1d2c4b6ef232123e7db2798c6b5422cf5a985df330R169-R259); `jira/internal/search_impl_rich_text.go`: [[3]](diffhunk://#diff-81689f98aedf8d01fd6b56bebdab18325c45c45569c4a7a105938a2197faf2f9R47-R73) [[4]](diffhunk://#diff-81689f98aedf8d01fd6b56bebdab18325c45c45569c4a7a105938a2197faf2f9R169-R259)

### Data Model Updates:

* **New Data Models**: Added new structs to represent responses for the new endpoints:
  - `IssueSearchApproximateCountScheme` for approximate count responses. (`pkg/infra/models/jira_search_count.go`: [pkg/infra/models/jira_search_count.goR1-R6](diffhunk://#diff-6a525072b53d97b12e798863a88db3333633538348824f3d3f93027621db9e20R1-R6))
  - `IssueSearchJQLScheme` and `IssueBulkFetchScheme` for ADF (v3 API). (`pkg/infra/models/jira_search_v3.go`: [pkg/infra/models/jira_search_v3.goR18-R33](diffhunk://#diff-55f4f921be80af72c8f86126c19d702c8dfe91dec23b9c4dd0e65a5bc2975fd1R18-R33))
  - `IssueSearchJQLSchemeV2` and `IssueBulkFetchSchemeV2` for Rich Text (v2 API). (`pkg/infra/models/jira_search_v2.go`: [pkg/infra/models/jira_search_v2.goR12-R27](diffhunk://#diff-d035e337c3f2be1aa1a431d6550b74bc5f35e5119daf25cd8f20f50bc6610cb9R12-R27))

### Codebase Maintenance:

* **Reorganized Imports**: Reordered imports in `jira/internal/search_impl_adf.go` and `jira/internal/search_impl_rich_text.go` for better readability and consistency. [[1]](diffhunk://#diff-5bf058e6cede7f34d445fa1d2c4b6ef232123e7db2798c6b5422cf5a985df330L6-R13) [[2]](diffhunk://#diff-81689f98aedf8d01fd6b56bebdab18325c45c45569c4a7a105938a2197faf2f9L6-R13)

These updates ensure the library stays aligned with Jira's evolving API, providing users with access to the latest features while preparing for the deprecation of older endpoints.

Fixes #345 