### PR TITLE
Ignore package comments and markdown length limit

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -1,3 +1,14 @@
 ---
 exclude_paths:
   - "**/*_test.go"
+
+# Disable specific rules
+tools:
+  revive:
+    enabled: true
+    ignore_patterns:
+      - Revive_package-comments # We don't care about package comments for now
+  markdownlint:
+    enabled: true
+    ignore_patterns:
+      - markdownlint_MD013  # Line length rule

--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ go get github.com/ctreminiom/go-atlassian/v2
 ## 📪 Packages
 Then import the package into your project as you normally would. You can import the following packages:
 
-| Module                                | Path                                                      | URL's                                                                                  |
-|--------------------------------------|-----------------------------------------------------------|----------------------------------------------------------------------------------------|
+| Module                              | Path                                                      | URL's                                                                                  |
+|-------------------------------------|-----------------------------------------------------------|----------------------------------------------------------------------------------------|
 | Jira v2                             | `github.com/ctreminiom/go-atlassian/v2/jira/v2`           | [Getting Started](https://docs.go-atlassian.io/jira-software-cloud/introduction)       |
 | Jira v3                             | `github.com/ctreminiom/go-atlassian/v2/jira/v3`           | [Getting Started](https://docs.go-atlassian.io/jira-software-cloud/introduction)       |
 | Jira Software Agile                 | `github.com/ctreminiom/go-atlassian/v2/jira/agile`        | [Getting Started](https://docs.go-atlassian.io/jira-agile/introduction)                |
@@ -58,7 +58,7 @@ Then import the package into your project as you normally would. You can import 
 | Confluence                          | `github.com/ctreminiom/go-atlassian/v2/confluence`        | [Getting Started](https://docs.go-atlassian.io/confluence-cloud/introduction)          |
 | Confluence v2                       | `github.com/ctreminiom/go-atlassian/v2/confluence/v2`     | [Getting Started](https://docs.go-atlassian.io/confluence-cloud/v2/introduction)       |
 | Admin Cloud                         | `github.com/ctreminiom/go-atlassian/v2/admin`             | [Getting Started](https://docs.go-atlassian.io/atlassian-admin-cloud/overview)         |
-| Bitbucket Cloud *(In Progress)*<br/> | `github.com/ctreminiom/go-atlassian/v2/bitbucket`        | [Getting Started](https://docs.go-atlassian.io/bitbucket-cloud/introduction)           |
+| Bitbucket Cloud *(In Progress)*     | `github.com/ctreminiom/go-atlassian/v2/bitbucket`         | [Getting Started](https://docs.go-atlassian.io/bitbucket-cloud/introduction)           |
 
 -------------------------
 ## 🔨 Usage

--- a/README.md
+++ b/README.md
@@ -48,17 +48,17 @@ go get github.com/ctreminiom/go-atlassian/v2
 ## 📪 Packages
 Then import the package into your project as you normally would. You can import the following packages:
 
-| Module                  	            | Path                                               	        | URL's                                                                                	 |
-|--------------------------------------|-------------------------------------------------------------|----------------------------------------------------------------------------------------|
-| Jira v2                 	            | `github.com/ctreminiom/go-atlassian/v2/jira/v2`       	     | [Getting Started](https://docs.go-atlassian.io/jira-software-cloud/introduction)     	 |
-| Jira v3                 	            | `github.com/ctreminiom/go-atlassian/v2/jira/v3`       	     | [Getting Started](https://docs.go-atlassian.io/jira-software-cloud/introduction)     	 |
-| Jira Software Agile     	            | `github.com/ctreminiom/go-atlassian/v2/jira/agile`    	     | [Getting Started](https://docs.go-atlassian.io/jira-agile/introduction)              	 |
-| Jira Service Management 	            | `github.com/ctreminiom/go-atlassian/v2/jira/sm`       	     | [Getting Started](https://docs.go-atlassian.io/jira-service-management/introduction) 	 |
-| Jira Assets             	            | `github.com/ctreminiom/go-atlassian/v2/assets`        	     | [Getting Started](https://docs.go-atlassian.io/jira-assets/overview)                 	 |
-| Confluence              	            | `github.com/ctreminiom/go-atlassian/v2/confluence`    	     | [Getting Started](https://docs.go-atlassian.io/confluence-cloud/introduction)        	 |
-| Confluence v2           	            | `github.com/ctreminiom/go-atlassian/v2/confluence/v2` 	     | [Getting Started](https://docs.go-atlassian.io/confluence-cloud/v2/introduction)     	 |
-| Admin Cloud             	            | `github.com/ctreminiom/go-atlassian/v2/admin`         	     | [Getting Started](https://docs.go-atlassian.io/atlassian-admin-cloud/overview)       	 |
-| Bitbucket Cloud *(In Progress)*<br/> | `github.com/ctreminiom/go-atlassian/v2/bitbucket`         	 | [Getting Started](https://docs.go-atlassian.io/bitbucket-cloud/introduction)       	   |
+| Module                                | Path                                                      | URL's                                                                                  |
+|--------------------------------------|-----------------------------------------------------------|----------------------------------------------------------------------------------------|
+| Jira v2                             | `github.com/ctreminiom/go-atlassian/v2/jira/v2`           | [Getting Started](https://docs.go-atlassian.io/jira-software-cloud/introduction)       |
+| Jira v3                             | `github.com/ctreminiom/go-atlassian/v2/jira/v3`           | [Getting Started](https://docs.go-atlassian.io/jira-software-cloud/introduction)       |
+| Jira Software Agile                 | `github.com/ctreminiom/go-atlassian/v2/jira/agile`        | [Getting Started](https://docs.go-atlassian.io/jira-agile/introduction)                |
+| Jira Service Management             | `github.com/ctreminiom/go-atlassian/v2/jira/sm`           | [Getting Started](https://docs.go-atlassian.io/jira-service-management/introduction)   |
+| Jira Assets                         | `github.com/ctreminiom/go-atlassian/v2/assets`            | [Getting Started](https://docs.go-atlassian.io/jira-assets/overview)                   |
+| Confluence                          | `github.com/ctreminiom/go-atlassian/v2/confluence`        | [Getting Started](https://docs.go-atlassian.io/confluence-cloud/introduction)          |
+| Confluence v2                       | `github.com/ctreminiom/go-atlassian/v2/confluence/v2`     | [Getting Started](https://docs.go-atlassian.io/confluence-cloud/v2/introduction)       |
+| Admin Cloud                         | `github.com/ctreminiom/go-atlassian/v2/admin`             | [Getting Started](https://docs.go-atlassian.io/atlassian-admin-cloud/overview)         |
+| Bitbucket Cloud *(In Progress)*<br/> | `github.com/ctreminiom/go-atlassian/v2/bitbucket`        | [Getting Started](https://docs.go-atlassian.io/bitbucket-cloud/introduction)           |
 
 -------------------------
 ## 🔨 Usage


### PR DESCRIPTION
This pull request updates the `.codacy.yml` configuration file to customize linting rules for the project. The changes introduce exclusions for specific rules in `revive` and `markdownlint` tools.

Linting configuration updates:

* Added a `tools` section to enable `revive` and `markdownlint` with specific rules ignored:
  - [`revive`](diffhunk://#diff-6e27af35533eda2e3e82d6d7f8654c26824396797716d37ac7df096a1b090503R4-R14): Ignored the `Revive_package-comments` rule to bypass package comment checks.
  - [`markdownlint`](diffhunk://#diff-6e27af35533eda2e3e82d6d7f8654c26824396797716d37ac7df096a1b090503R4-R14): Ignored the `markdownlint_MD013` rule to disable the line length restriction.