### PR TITLE
🐛 Fixed Assets IncludeAttributesDeep type

### DIFF
--- a/assets/internal/aql_impl_test.go
+++ b/assets/internal/aql_impl_test.go
@@ -3,12 +3,13 @@ package internal
 import (
 	"context"
 	"errors"
+	"net/http"
+	"testing"
+
 	model "github.com/ctreminiom/go-atlassian/v2/pkg/infra/models"
 	"github.com/ctreminiom/go-atlassian/v2/service"
 	"github.com/ctreminiom/go-atlassian/v2/service/mocks"
 	"github.com/stretchr/testify/assert"
-	"net/http"
-	"testing"
 )
 
 func Test_internalAQLImpl_Filter(t *testing.T) {
@@ -18,7 +19,7 @@ func Test_internalAQLImpl_Filter(t *testing.T) {
 		Page:                  2,
 		ResultPerPage:         25,
 		IncludeAttributes:     true,
-		IncludeAttributesDeep: true,
+		IncludeAttributesDeep: 12,
 		IncludeTypeAttributes: true,
 		IncludeExtendedInfo:   true,
 	}
@@ -55,7 +56,7 @@ func Test_internalAQLImpl_Filter(t *testing.T) {
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodGet,
-					"jsm/assets/workspace/workspace-uuid-sample/v1/aql/objects?includeAttributes=true&includeAttributesDeep=true&includeExtendedInfo=true&includeTypeAttributes=true&page=2&qlQuery=Name+LIKE+Test&resultPerPage=25",
+					"jsm/assets/workspace/workspace-uuid-sample/v1/aql/objects?includeAttributes=true&includeAttributesDeep=12&includeExtendedInfo=true&includeTypeAttributes=true&page=2&qlQuery=Name+LIKE+Test&resultPerPage=25",
 					"",
 					nil).
 					Return(&http.Request{}, nil)
@@ -83,7 +84,7 @@ func Test_internalAQLImpl_Filter(t *testing.T) {
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodGet,
-					"jsm/assets/workspace/workspace-uuid-sample/v1/aql/objects?includeAttributes=true&includeAttributesDeep=true&includeExtendedInfo=true&includeTypeAttributes=true&page=2&qlQuery=Name+LIKE+Test&resultPerPage=25",
+					"jsm/assets/workspace/workspace-uuid-sample/v1/aql/objects?includeAttributes=true&includeAttributesDeep=12&includeExtendedInfo=true&includeTypeAttributes=true&page=2&qlQuery=Name+LIKE+Test&resultPerPage=25",
 					"",
 					nil).
 					Return(&http.Request{}, errors.New("error, unable to create the http request"))

--- a/pkg/infra/models/assets_aql.go
+++ b/pkg/infra/models/assets_aql.go
@@ -17,7 +17,7 @@ type AQLSearchParamsScheme struct {
 	IncludeAttributes bool `query:"includeAttributes,omitempty"`
 
 	// IncludeAttributesDeep determines how many levels of attributes should be included.
-	IncludeAttributesDeep bool `query:"includeAttributesDeep,omitempty"`
+	IncludeAttributesDeep int `query:"includeAttributesDeep,omitempty"`
 
 	// IncludeTypeAttributes determines if the response should include the object type attribute definition for each attribute returned with the objects.
 	IncludeTypeAttributes bool `query:"includeTypeAttributes,omitempty"`


### PR DESCRIPTION
This pull request updates the `IncludeAttributesDeep` field in the AQL implementation to change its type from `bool` to `int`, reflecting a shift in how attribute depth is handled. Corresponding test cases and request logic have been updated to align with this change.

### Changes related to `IncludeAttributesDeep` field:

* [`pkg/infra/models/assets_aql.go`](diffhunk://#diff-aa615e70b3a53db3f7e9ae19c215a5d8e0564f7b3ec7829c625b411a005bcc86L20-R20): Changed the type of the `IncludeAttributesDeep` field in the `AQLSearchParamsScheme` struct from `bool` to `int`. This allows specifying the depth of attributes as an integer rather than a boolean.

### Updates to test cases:

* [`assets/internal/aql_impl_test.go`](diffhunk://#diff-677f8f00b4af10ff25bc2a96bb2cb9ccae6c60e6bcc84ed75649bf88d9e73ec7L21-R22): Updated test cases in `Test_internalAQLImpl_Filter` to reflect the type change of `IncludeAttributesDeep`. The value is now set to `12` instead of `true`.
* [`assets/internal/aql_impl_test.go`](diffhunk://#diff-677f8f00b4af10ff25bc2a96bb2cb9ccae6c60e6bcc84ed75649bf88d9e73ec7L58-R59): Adjusted the expected URL in mocked HTTP requests to include `includeAttributesDeep=12` instead of `includeAttributesDeep=true`. This ensures tests validate the new behavior. [[1]](diffhunk://#diff-677f8f00b4af10ff25bc2a96bb2cb9ccae6c60e6bcc84ed75649bf88d9e73ec7L58-R59) [[2]](diffhunk://#diff-677f8f00b4af10ff25bc2a96bb2cb9ccae6c60e6bcc84ed75649bf88d9e73ec7L86-R87)

### Minor code reorganization:

* [`assets/internal/aql_impl_test.go`](diffhunk://#diff-677f8f00b4af10ff25bc2a96bb2cb9ccae6c60e6bcc84ed75649bf88d9e73ec7R6-L11): Reorganized import statements to group standard library imports together and third-party imports separately.

Fixes #331