### PR TITLE
Allow special keyword "null" in assign user

### DIFF
--- a/jira/internal/issue_impl.go
+++ b/jira/internal/issue_impl.go
@@ -146,7 +146,16 @@ func assignIssue(ctx context.Context, client service.Connector, version, issueKe
 
 	endpoint := fmt.Sprintf("/rest/api/%v/issue/%v/assignee", version, issueKeyOrID)
 
-	request, err := client.NewRequest(ctx, http.MethodPut, endpoint, "", map[string]interface{}{"accountId": accountID})
+	var payload map[string]interface{}
+	if accountID == "null" {
+		// Special case: if "null" is passed, send a JSON null value to unassign the issue
+		// TODO: allow the user to pass a nil value in next major version
+		payload = map[string]interface{}{"accountId": nil}
+	} else {
+		payload = map[string]interface{}{"accountId": accountID}
+	}
+
+	request, err := client.NewRequest(ctx, http.MethodPut, endpoint, "", payload)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This pull request introduces a change to the `assignIssue` function in `jira/internal/issue_impl.go` to handle a special case for unassigning issues. The key update ensures that passing the string `"null"` as the `accountID` results in sending a JSON `null` value in the request payload, improving the clarity and functionality of the API.

### Key change:
* [`jira/internal/issue_impl.go`](diffhunk://#diff-a355e5a762904fef5c72077d1f1740e8751d6d2a59ad661c7e0884d30a0e3468L149-R158): Updated the `assignIssue` function to handle the special case where `"null"` is passed as the `accountID`. This now sends a JSON `null` value in the payload to unassign the issue, with a note to allow passing a `nil` value in the next major version.

Fixes #355 