### PR TITLE
Added dedicated revive.toml config

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -1,13 +1,8 @@
----
 exclude_paths:
   - "**/*_test.go"
 
 # Disable specific rules
-tools:
-  revive:
-    enabled: true
-    ignore_patterns:
-      - Revive_package-comments # We don't care about package comments for now
+engines:
   markdownlint:
     enabled: true
     ignore_patterns:

--- a/revive.toml
+++ b/revive.toml
@@ -1,0 +1,3 @@
+# We don't care about package comments for now
+[rule.package-comments]
+	Disabled = true


### PR DESCRIPTION
This pull request updates the configuration for code quality tools by migrating a rule exclusion from `.codacy.yml` to `revive.toml`. This change simplifies the `.codacy.yml` file and ensures the rule exclusion is handled directly in the `revive` configuration.

Configuration updates:

* [`.codacy.yml`](diffhunk://#diff-6e27af35533eda2e3e82d6d7f8654c26824396797716d37ac7df096a1b090503L1-R5): Removed the `revive` tool configuration, including the exclusion of the `Revive_package-comments` rule, and replaced it with the `markdownlint` engine configuration.
* [`revive.toml`](diffhunk://#diff-8b0ccb1cda99e7695c615291c714e430fe4c3552b6da8b10f82f12c6392521acR1-R3): Added a rule to disable `package-comments`, aligning with the previous exclusion in `.codacy.yml`.