### PR TITLE
✨ Added mypreferences

### DIFF
--- a/jira/internal/myself_impl.go
+++ b/jira/internal/myself_impl.go
@@ -3,12 +3,13 @@ package internal
 import (
 	"context"
 	"fmt"
-	model "github.com/ctreminiom/go-atlassian/v2/pkg/infra/models"
-	"github.com/ctreminiom/go-atlassian/v2/service"
-	"github.com/ctreminiom/go-atlassian/v2/service/jira"
 	"net/http"
 	"net/url"
 	"strings"
+
+	model "github.com/ctreminiom/go-atlassian/v2/pkg/infra/models"
+	"github.com/ctreminiom/go-atlassian/v2/service"
+	"github.com/ctreminiom/go-atlassian/v2/service/jira"
 )
 
 // NewMySelfService creates a new instance of MySelfService.
@@ -36,6 +37,33 @@ type MySelfService struct {
 // https://docs.go-atlassian.io/jira-software-cloud/myself#get-current-user
 func (m *MySelfService) Details(ctx context.Context, expand []string) (*model.UserScheme, *model.ResponseScheme, error) {
 	return m.internalClient.Details(ctx, expand)
+}
+
+// Get returns the values of the user's preferences.
+//
+// GET /rest/api/{2-3}/mypreferences
+//
+// https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-myself/#api-rest-api-3-mypreferences-get
+func (m *MySelfService) Get(ctx context.Context, key string) (map[string]interface{}, *model.ResponseScheme, error) {
+	return m.internalClient.Get(ctx, key)
+}
+
+// Set sets the value of the user's preference.
+//
+// PUT /rest/api/{2-3}/mypreferences
+//
+// https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-myself/#api-rest-api-3-mypreferences-put
+func (m *MySelfService) Set(ctx context.Context, key string, value string) (map[string]interface{}, *model.ResponseScheme, error) {
+	return m.internalClient.Set(ctx, key, value)
+}
+
+// Delete deletes the user's preference.
+//
+// DELETE /rest/api/{2-3}/mypreferences
+//
+// https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-myself/#api-rest-api-3-mypreferences-delete
+func (m *MySelfService) Delete(ctx context.Context, key string) (*model.ResponseScheme, error) {
+	return m.internalClient.Delete(ctx, key)
 }
 
 type internalMySelfImpl struct {
@@ -68,4 +96,88 @@ func (i *internalMySelfImpl) Details(ctx context.Context, expand []string) (*mod
 	}
 
 	return my, response, nil
+}
+
+func (i *internalMySelfImpl) Get(ctx context.Context, key string) (map[string]interface{}, *model.ResponseScheme, error) {
+
+	var endpoint strings.Builder
+	endpoint.WriteString(fmt.Sprintf("rest/api/%v/mypreferences", i.version))
+
+	if key != "" {
+		params := url.Values{}
+		params.Add("key", key)
+		endpoint.WriteString(fmt.Sprintf("?%v", params.Encode()))
+	}
+
+	request, err := i.c.NewRequest(ctx, http.MethodGet, endpoint.String(), "", nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	preferences := make(map[string]interface{})
+	response, err := i.c.Call(request, &preferences)
+	if err != nil {
+		return nil, response, err
+	}
+
+	return preferences, response, nil
+}
+
+func (i *internalMySelfImpl) Set(ctx context.Context, key string, value string) (map[string]interface{}, *model.ResponseScheme, error) {
+
+	if key == "" {
+		return nil, nil, model.ErrNoKeyError
+	}
+
+	var endpoint strings.Builder
+	endpoint.WriteString(fmt.Sprintf("rest/api/%v/mypreferences", i.version))
+
+	params := url.Values{}
+	params.Add("key", key)
+	endpoint.WriteString(fmt.Sprintf("?%v", params.Encode()))
+
+	payload := struct {
+		Value string `json:"value"`
+	}{
+		Value: value,
+	}
+
+	request, err := i.c.NewRequest(ctx, http.MethodPut, endpoint.String(), "", payload)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	preferences := make(map[string]interface{})
+	response, err := i.c.Call(request, &preferences)
+	if err != nil {
+		return nil, response, err
+	}
+
+	return preferences, response, nil
+}
+
+func (i *internalMySelfImpl) Delete(ctx context.Context, key string) (*model.ResponseScheme, error) {
+
+	if key == "" {
+		return nil, model.ErrNoKeyError
+	}
+
+	var endpoint strings.Builder
+	endpoint.WriteString(fmt.Sprintf("rest/api/%v/mypreferences", i.version))
+
+	params := url.Values{}
+	params.Add("key", key)
+	endpoint.WriteString(fmt.Sprintf("?%v", params.Encode()))
+
+	request, err := i.c.NewRequest(ctx, http.MethodDelete, endpoint.String(), "", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	response, err := i.c.Call(request, nil)
+	if err != nil {
+		return response, err
+	}
+
+	return response, nil
 }

--- a/jira/internal/myself_impl_test.go
+++ b/jira/internal/myself_impl_test.go
@@ -3,12 +3,13 @@ package internal
 import (
 	"context"
 	"errors"
+	"net/http"
+	"testing"
+
 	model "github.com/ctreminiom/go-atlassian/v2/pkg/infra/models"
 	"github.com/ctreminiom/go-atlassian/v2/service"
 	"github.com/ctreminiom/go-atlassian/v2/service/mocks"
 	"github.com/stretchr/testify/assert"
-	"net/http"
-	"testing"
 )
 
 func Test_internalMySelfImpl_Details(t *testing.T) {
@@ -193,6 +194,573 @@ func Test_NewMySelfService(t *testing.T) {
 
 				assert.NoError(t, err)
 				assert.NotEqual(t, got, nil)
+			}
+		})
+	}
+}
+
+func Test_internalMySelfImpl_Get(t *testing.T) {
+
+	type fields struct {
+		c       service.Connector
+		version string
+	}
+
+	type args struct {
+		ctx context.Context
+		key string
+	}
+
+	testCases := []struct {
+		name    string
+		fields  fields
+		args    args
+		on      func(*fields)
+		wantErr bool
+		Err     error
+	}{
+		{
+			name:   "when the api version is v3 with key parameter",
+			fields: fields{version: "3"},
+			args: args{
+				ctx: context.Background(),
+				key: "myuser.thousand.separator",
+			},
+			on: func(fields *fields) {
+
+				client := mocks.NewConnector(t)
+
+				client.On("NewRequest",
+					context.Background(),
+					http.MethodGet,
+					"rest/api/3/mypreferences?key=myuser.thousand.separator",
+					"", nil).
+					Return(&http.Request{}, nil)
+
+				client.On("Call",
+					&http.Request{},
+					&map[string]interface{}{}).
+					Return(&model.ResponseScheme{}, nil)
+
+				fields.c = client
+			},
+			wantErr: false,
+			Err:     nil,
+		},
+
+		{
+			name:   "when the api version is v3 without key parameter",
+			fields: fields{version: "3"},
+			args: args{
+				ctx: context.Background(),
+				key: "",
+			},
+			on: func(fields *fields) {
+
+				client := mocks.NewConnector(t)
+
+				client.On("NewRequest",
+					context.Background(),
+					http.MethodGet,
+					"rest/api/3/mypreferences",
+					"", nil).
+					Return(&http.Request{}, nil)
+
+				client.On("Call",
+					&http.Request{},
+					&map[string]interface{}{}).
+					Return(&model.ResponseScheme{}, nil)
+
+				fields.c = client
+			},
+			wantErr: false,
+			Err:     nil,
+		},
+
+		{
+			name:   "when the api version is v2 with key parameter",
+			fields: fields{version: "2"},
+			args: args{
+				ctx: context.Background(),
+				key: "user.notifications.assignee.field",
+			},
+			on: func(fields *fields) {
+
+				client := mocks.NewConnector(t)
+
+				client.On("NewRequest",
+					context.Background(),
+					http.MethodGet,
+					"rest/api/2/mypreferences?key=user.notifications.assignee.field",
+					"", nil).
+					Return(&http.Request{}, nil)
+
+				client.On("Call",
+					&http.Request{},
+					&map[string]interface{}{}).
+					Return(&model.ResponseScheme{}, nil)
+
+				fields.c = client
+			},
+			wantErr: false,
+			Err:     nil,
+		},
+
+		{
+			name:   "when the http request cannot be created",
+			fields: fields{version: "3"},
+			args: args{
+				ctx: context.Background(),
+				key: "myuser.thousand.separator",
+			},
+			on: func(fields *fields) {
+
+				client := mocks.NewConnector(t)
+
+				client.On("NewRequest",
+					context.Background(),
+					http.MethodGet,
+					"rest/api/3/mypreferences?key=myuser.thousand.separator",
+					"", nil).
+					Return(&http.Request{}, errors.New("error, unable to create the http request"))
+
+				fields.c = client
+			},
+			wantErr: true,
+			Err:     errors.New("error, unable to create the http request"),
+		},
+
+		{
+			name:   "when the API call returns an error",
+			fields: fields{version: "3"},
+			args: args{
+				ctx: context.Background(),
+				key: "myuser.thousand.separator",
+			},
+			on: func(fields *fields) {
+
+				client := mocks.NewConnector(t)
+
+				client.On("NewRequest",
+					context.Background(),
+					http.MethodGet,
+					"rest/api/3/mypreferences?key=myuser.thousand.separator",
+					"", nil).
+					Return(&http.Request{}, nil)
+
+				client.On("Call",
+					&http.Request{},
+					&map[string]interface{}{}).
+					Return(&model.ResponseScheme{}, errors.New("error, unable to execute API call"))
+
+				fields.c = client
+			},
+			wantErr: true,
+			Err:     errors.New("error, unable to execute API call"),
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+
+			if testCase.on != nil {
+				testCase.on(&testCase.fields)
+			}
+
+			service := internalMySelfImpl{
+				c:       testCase.fields.c,
+				version: testCase.fields.version,
+			}
+
+			gotResult, gotResponse, err := service.Get(testCase.args.ctx, testCase.args.key)
+
+			if testCase.wantErr {
+
+				if err != nil {
+					t.Logf("error returned: %v", err.Error())
+				}
+
+				assert.EqualError(t, err, testCase.Err.Error())
+			} else {
+
+				assert.NoError(t, err)
+				assert.NotEqual(t, gotResponse, nil)
+				assert.NotEqual(t, gotResult, nil)
+			}
+		})
+	}
+}
+
+func Test_internalMySelfImpl_Set(t *testing.T) {
+
+	type fields struct {
+		c       service.Connector
+		version string
+	}
+
+	type args struct {
+		ctx   context.Context
+		key   string
+		value string
+	}
+
+	testCases := []struct {
+		name    string
+		fields  fields
+		args    args
+		on      func(*fields)
+		wantErr bool
+		Err     error
+	}{
+		{
+			name:   "when the api version is v3",
+			fields: fields{version: "3"},
+			args: args{
+				ctx:   context.Background(),
+				key:   "myuser.thousand.separator",
+				value: ",",
+			},
+			on: func(fields *fields) {
+
+				client := mocks.NewConnector(t)
+
+				client.On("NewRequest",
+					context.Background(),
+					http.MethodPut,
+					"rest/api/3/mypreferences?key=myuser.thousand.separator",
+					"",
+					struct {
+						Value string `json:"value"`
+					}{
+						Value: ",",
+					}).
+					Return(&http.Request{}, nil)
+
+				client.On("Call",
+					&http.Request{},
+					&map[string]interface{}{}).
+					Return(&model.ResponseScheme{}, nil)
+
+				fields.c = client
+			},
+			wantErr: false,
+			Err:     nil,
+		},
+
+		{
+			name:   "when the api version is v2",
+			fields: fields{version: "2"},
+			args: args{
+				ctx:   context.Background(),
+				key:   "user.notifications.assignee.field",
+				value: "assignee",
+			},
+			on: func(fields *fields) {
+
+				client := mocks.NewConnector(t)
+
+				client.On("NewRequest",
+					context.Background(),
+					http.MethodPut,
+					"rest/api/2/mypreferences?key=user.notifications.assignee.field",
+					"",
+					struct {
+						Value string `json:"value"`
+					}{
+						Value: "assignee",
+					}).
+					Return(&http.Request{}, nil)
+
+				client.On("Call",
+					&http.Request{},
+					&map[string]interface{}{}).
+					Return(&model.ResponseScheme{}, nil)
+
+				fields.c = client
+			},
+			wantErr: false,
+			Err:     nil,
+		},
+
+		{
+			name:   "when the key is not provided",
+			fields: fields{version: "3"},
+			args: args{
+				ctx:   context.Background(),
+				key:   "",
+				value: ",",
+			},
+			on:      nil,
+			wantErr: true,
+			Err:     model.ErrNoKeyError,
+		},
+
+		{
+			name:   "when the http request cannot be created",
+			fields: fields{version: "3"},
+			args: args{
+				ctx:   context.Background(),
+				key:   "myuser.thousand.separator",
+				value: ",",
+			},
+			on: func(fields *fields) {
+
+				client := mocks.NewConnector(t)
+
+				client.On("NewRequest",
+					context.Background(),
+					http.MethodPut,
+					"rest/api/3/mypreferences?key=myuser.thousand.separator",
+					"",
+					struct {
+						Value string `json:"value"`
+					}{
+						Value: ",",
+					}).
+					Return(&http.Request{}, errors.New("error, unable to create the http request"))
+
+				fields.c = client
+			},
+			wantErr: true,
+			Err:     errors.New("error, unable to create the http request"),
+		},
+
+		{
+			name:   "when the API call returns an error",
+			fields: fields{version: "3"},
+			args: args{
+				ctx:   context.Background(),
+				key:   "myuser.thousand.separator",
+				value: ",",
+			},
+			on: func(fields *fields) {
+
+				client := mocks.NewConnector(t)
+
+				client.On("NewRequest",
+					context.Background(),
+					http.MethodPut,
+					"rest/api/3/mypreferences?key=myuser.thousand.separator",
+					"",
+					struct {
+						Value string `json:"value"`
+					}{
+						Value: ",",
+					}).
+					Return(&http.Request{}, nil)
+
+				client.On("Call",
+					&http.Request{},
+					&map[string]interface{}{}).
+					Return(&model.ResponseScheme{}, errors.New("error, unable to execute API call"))
+
+				fields.c = client
+			},
+			wantErr: true,
+			Err:     errors.New("error, unable to execute API call"),
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+
+			if testCase.on != nil {
+				testCase.on(&testCase.fields)
+			}
+
+			service := internalMySelfImpl{
+				c:       testCase.fields.c,
+				version: testCase.fields.version,
+			}
+
+			gotResult, gotResponse, err := service.Set(testCase.args.ctx, testCase.args.key, testCase.args.value)
+
+			if testCase.wantErr {
+
+				if err != nil {
+					t.Logf("error returned: %v", err.Error())
+				}
+
+				assert.EqualError(t, err, testCase.Err.Error())
+			} else {
+
+				assert.NoError(t, err)
+				assert.NotEqual(t, gotResponse, nil)
+				assert.NotEqual(t, gotResult, nil)
+			}
+		})
+	}
+}
+
+func Test_internalMySelfImpl_Delete(t *testing.T) {
+
+	type fields struct {
+		c       service.Connector
+		version string
+	}
+
+	type args struct {
+		ctx context.Context
+		key string
+	}
+
+	testCases := []struct {
+		name    string
+		fields  fields
+		args    args
+		on      func(*fields)
+		wantErr bool
+		Err     error
+	}{
+		{
+			name:   "when the api version is v3",
+			fields: fields{version: "3"},
+			args: args{
+				ctx: context.Background(),
+				key: "myuser.thousand.separator",
+			},
+			on: func(fields *fields) {
+
+				client := mocks.NewConnector(t)
+
+				client.On("NewRequest",
+					context.Background(),
+					http.MethodDelete,
+					"rest/api/3/mypreferences?key=myuser.thousand.separator",
+					"", nil).
+					Return(&http.Request{}, nil)
+
+				client.On("Call",
+					&http.Request{},
+					nil).
+					Return(&model.ResponseScheme{}, nil)
+
+				fields.c = client
+			},
+			wantErr: false,
+			Err:     nil,
+		},
+
+		{
+			name:   "when the api version is v2",
+			fields: fields{version: "2"},
+			args: args{
+				ctx: context.Background(),
+				key: "user.notifications.assignee.field",
+			},
+			on: func(fields *fields) {
+
+				client := mocks.NewConnector(t)
+
+				client.On("NewRequest",
+					context.Background(),
+					http.MethodDelete,
+					"rest/api/2/mypreferences?key=user.notifications.assignee.field",
+					"", nil).
+					Return(&http.Request{}, nil)
+
+				client.On("Call",
+					&http.Request{},
+					nil).
+					Return(&model.ResponseScheme{}, nil)
+
+				fields.c = client
+			},
+			wantErr: false,
+			Err:     nil,
+		},
+
+		{
+			name:   "when the key is not provided",
+			fields: fields{version: "3"},
+			args: args{
+				ctx: context.Background(),
+				key: "",
+			},
+			on:      nil,
+			wantErr: true,
+			Err:     model.ErrNoKeyError,
+		},
+
+		{
+			name:   "when the http request cannot be created",
+			fields: fields{version: "3"},
+			args: args{
+				ctx: context.Background(),
+				key: "myuser.thousand.separator",
+			},
+			on: func(fields *fields) {
+
+				client := mocks.NewConnector(t)
+
+				client.On("NewRequest",
+					context.Background(),
+					http.MethodDelete,
+					"rest/api/3/mypreferences?key=myuser.thousand.separator",
+					"", nil).
+					Return(&http.Request{}, errors.New("error, unable to create the http request"))
+
+				fields.c = client
+			},
+			wantErr: true,
+			Err:     errors.New("error, unable to create the http request"),
+		},
+
+		{
+			name:   "when the API call returns an error",
+			fields: fields{version: "3"},
+			args: args{
+				ctx: context.Background(),
+				key: "myuser.thousand.separator",
+			},
+			on: func(fields *fields) {
+
+				client := mocks.NewConnector(t)
+
+				client.On("NewRequest",
+					context.Background(),
+					http.MethodDelete,
+					"rest/api/3/mypreferences?key=myuser.thousand.separator",
+					"", nil).
+					Return(&http.Request{}, nil)
+
+				client.On("Call",
+					&http.Request{},
+					nil).
+					Return(&model.ResponseScheme{}, errors.New("error, unable to execute API call"))
+
+				fields.c = client
+			},
+			wantErr: true,
+			Err:     errors.New("error, unable to execute API call"),
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+
+			if testCase.on != nil {
+				testCase.on(&testCase.fields)
+			}
+
+			service := internalMySelfImpl{
+				c:       testCase.fields.c,
+				version: testCase.fields.version,
+			}
+
+			gotResponse, err := service.Delete(testCase.args.ctx, testCase.args.key)
+
+			if testCase.wantErr {
+
+				if err != nil {
+					t.Logf("error returned: %v", err.Error())
+				}
+
+				assert.EqualError(t, err, testCase.Err.Error())
+			} else {
+
+				assert.NoError(t, err)
+				assert.NotEqual(t, gotResponse, nil)
 			}
 		})
 	}

--- a/pkg/infra/models/errors.go
+++ b/pkg/infra/models/errors.go
@@ -172,4 +172,5 @@ var (
 	ErrNoMemberID                     = errors.New("bitbucket: no member id set")
 	ErrNoWebhookID                    = errors.New("bitbucket: no webhook id set")
 	ErrNoRepository                   = errors.New("bitbucket: no repository set")
+	ErrNoKeyError                     = errors.New("jira: no key set")
 )

--- a/service/jira/myself.go
+++ b/service/jira/myself.go
@@ -2,6 +2,7 @@ package jira
 
 import (
 	"context"
+
 	model "github.com/ctreminiom/go-atlassian/v2/pkg/infra/models"
 )
 
@@ -13,4 +14,25 @@ type MySelfConnector interface {
 	//
 	// https://docs.go-atlassian.io/jira-software-cloud/myself#get-current-user
 	Details(ctx context.Context, expand []string) (*model.UserScheme, *model.ResponseScheme, error)
+
+	// Get returns the values of the user's preferences.
+	//
+	// GET /rest/api/{2-3}/mypreferences
+	//
+	// https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-myself/#api-rest-api-3-mypreferences-get
+	Get(ctx context.Context, key string) (map[string]interface{}, *model.ResponseScheme, error)
+
+	// Set sets the value of the user's preference.
+	//
+	// PUT /rest/api/{2-3}/mypreferences
+	//
+	// https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-myself/#api-rest-api-3-mypreferences-put
+	Set(ctx context.Context, key string, value string) (map[string]interface{}, *model.ResponseScheme, error)
+
+	// Delete deletes the user's preference.
+	//
+	// DELETE /rest/api/{2-3}/mypreferences
+	//
+	// https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-myself/#api-rest-api-3-mypreferences-delete
+	Delete(ctx context.Context, key string) (*model.ResponseScheme, error)
 }


### PR DESCRIPTION
This pull request introduces new functionality for managing user preferences in the Jira API client. It adds methods to retrieve, set, and delete user preferences, along with the necessary infrastructure to support these operations.

### New functionality for managing user preferences:

* **Added methods in `MySelfService` for user preferences:**
  - Introduced `Get`, `Set`, and `Delete` methods to retrieve, update, and delete user preferences, respectively. These methods are implemented in both the `MySelfService` interface and its internal implementation (`internalMySelfImpl`). [[1]](diffhunk://#diff-8d49505c63afe44de6ef78ffd2d661231e59a55650494c89efb6db0c0c0845c1R42-R68) [[2]](diffhunk://#diff-8d49505c63afe44de6ef78ffd2d661231e59a55650494c89efb6db0c0c0845c1R100-R183) [[3]](diffhunk://#diff-d4efa443c7561297409b1d70c846109d9a13634afcbf942a768389ecf08ae771R17-R37)

* **Error handling for missing keys:**
  - Added a new error constant `ErrNoKeyError` in `errors.go` to handle cases where a required key is not provided.

### Code organization and imports:

* **Reorganized imports in `jira/internal/myself_impl.go` and `service/jira/myself.go`:**
  - Adjusted import order for better readability and consistency. [[1]](diffhunk://#diff-8d49505c63afe44de6ef78ffd2d661231e59a55650494c89efb6db0c0c0845c1L6-R12) [[2]](diffhunk://#diff-d4efa443c7561297409b1d70c846109d9a13634afcbf942a768389ecf08ae771R5)

Fixes #151 
Fixes #152 
Fixes #153