### PR TITLE
Added documentation about deprecations

### DIFF
--- a/jira/internal/issue_impl_adf.go
+++ b/jira/internal/issue_impl_adf.go
@@ -199,6 +199,9 @@ func (i *internalIssueADFServiceImpl) Create(ctx context.Context, payload *model
 		body = payloadWithFields
 	}
 
+	// TODO: Missing optional updateHistory query parameter from API spec (default: false).
+	// When true, adds the project to the user's Recently viewed project list.
+	// Cannot add without breaking API compatibility. Consider adding in next major version.
 	endpoint := fmt.Sprintf("rest/api/%v/issue", i.version)
 	request, err := i.c.NewRequest(ctx, http.MethodPost, endpoint, "", body)
 	if err != nil {

--- a/jira/internal/issue_impl_rich_text.go
+++ b/jira/internal/issue_impl_rich_text.go
@@ -199,6 +199,9 @@ func (i *internalRichTextServiceImpl) Create(ctx context.Context, payload *model
 		body = payloadWithFields
 	}
 
+	// TODO: Missing optional updateHistory query parameter from API spec (default: false).
+	// When true, adds the project to the user's Recently viewed project list.
+	// Cannot add without breaking API compatibility. Consider adding in next major version.
 	endpoint := fmt.Sprintf("rest/api/%v/issue", i.version)
 	request, err := i.c.NewRequest(ctx, http.MethodPost, endpoint, "", body)
 	if err != nil {

--- a/jira/internal/metadata_impl.go
+++ b/jira/internal/metadata_impl.go
@@ -55,7 +55,7 @@ func (m *MetadataService) Get(ctx context.Context, issueKeyOrID string, override
 //
 // https://docs.go-atlassian.io/jira-software-cloud/issues/metadata#get-create-issue-metadata
 // Deprecated: This endpoint is deprecated in the Jira API spec.
-// TODO Cannot change without breaking API compatibility. Consider removing in next major version.
+// TODO: Cannot change without breaking API compatibility. Consider removing in next major version.
 func (m *MetadataService) Create(ctx context.Context, opts *model.IssueMetadataCreateOptions) (gjson.Result, *model.ResponseScheme, error) {
 	return m.internalClient.Create(ctx, opts)
 }

--- a/jira/internal/metadata_impl.go
+++ b/jira/internal/metadata_impl.go
@@ -54,6 +54,8 @@ func (m *MetadataService) Get(ctx context.Context, issueKeyOrID string, override
 // GET /rest/api/{2-3}/issue/createmeta
 //
 // https://docs.go-atlassian.io/jira-software-cloud/issues/metadata#get-create-issue-metadata
+// Deprecated: This endpoint is deprecated in the Jira API spec.
+// TODO Cannot change without breaking API compatibility. Consider removing in next major version.
 func (m *MetadataService) Create(ctx context.Context, opts *model.IssueMetadataCreateOptions) (gjson.Result, *model.ResponseScheme, error) {
 	return m.internalClient.Create(ctx, opts)
 }

--- a/jira/internal/priority_impl.go
+++ b/jira/internal/priority_impl.go
@@ -34,7 +34,7 @@ type PriorityService struct {
 //
 // https://docs.go-atlassian.io/jira-software-cloud/issues/priorities#get-priorities
 // Deprecated: This endpoint is deprecated in the Jira API spec.
-// TODO Cannot change without breaking API compatibility. Consider removing in next major version.
+// TODO: Cannot change without breaking API compatibility. Consider removing in next major version.
 func (p *PriorityService) Gets(ctx context.Context) ([]*model.PriorityScheme, *model.ResponseScheme, error) {
 	return p.internalClient.Gets(ctx)
 }

--- a/jira/internal/priority_impl.go
+++ b/jira/internal/priority_impl.go
@@ -33,6 +33,8 @@ type PriorityService struct {
 // GET /rest/api/{2-3}/priority
 //
 // https://docs.go-atlassian.io/jira-software-cloud/issues/priorities#get-priorities
+// Deprecated: This endpoint is deprecated in the Jira API spec.
+// TODO Cannot change without breaking API compatibility. Consider removing in next major version.
 func (p *PriorityService) Gets(ctx context.Context) ([]*model.PriorityScheme, *model.ResponseScheme, error) {
 	return p.internalClient.Gets(ctx)
 }
@@ -42,6 +44,8 @@ func (p *PriorityService) Gets(ctx context.Context) ([]*model.PriorityScheme, *m
 // GET /rest/api/{2-3}/priority/{priorityID}
 //
 // https://docs.go-atlassian.io/jira-software-cloud/issues/priorities#get-priority
+// Deprecated: This endpoint is deprecated in the Jira API spec.
+// TODO Cannot change without breaking API compatibility. Consider removing in next major version.
 func (p *PriorityService) Get(ctx context.Context, priorityID string) (*model.PriorityScheme, *model.ResponseScheme, error) {
 	return p.internalClient.Get(ctx, priorityID)
 }

--- a/jira/internal/project_impl.go
+++ b/jira/internal/project_impl.go
@@ -100,7 +100,7 @@ func (p *ProjectService) Search(ctx context.Context, options *model.ProjectSearc
 
 // Get returns the project details for a project.
 //
-// GET /rest/api/{2-3}project/{projectKeyOrID}
+// GET /rest/api/{2-3}/project/{projectKeyOrID}
 //
 // https://docs.go-atlassian.io/jira-software-cloud/projects#get-project
 func (p *ProjectService) Get(ctx context.Context, projectKeyOrID string, expand []string) (*model.ProjectScheme, *model.ResponseScheme, error) {

--- a/jira/internal/search_impl_adf.go
+++ b/jira/internal/search_impl_adf.go
@@ -35,8 +35,7 @@ func (s *SearchADFService) Checks(ctx context.Context, payload *model.IssueSearc
 // https://docs.go-atlassian.io/jira-software-cloud/issues/search#search-for-issues-using-jql-get
 //
 // Deprecated: This endpoint will be removed after May 1, 2025. Use SearchJQL, BulkFetch and ApproximateCount instead.
-// TODO: Implementation still uses deprecated GET /rest/api/3/search endpoint.
-// Cannot change without breaking API compatibility. Consider removing in next major version.
+// TODO Cannot change without breaking API compatibility. Consider removing in next major version.
 func (s *SearchADFService) Get(ctx context.Context, jql string, fields, expands []string, startAt, maxResults int, validate string) (*model.IssueSearchScheme, *model.ResponseScheme, error) {
 	return s.internalClient.Get(ctx, jql, fields, expands, startAt, maxResults, validate)
 }
@@ -48,8 +47,7 @@ func (s *SearchADFService) Get(ctx context.Context, jql string, fields, expands 
 // https://docs.go-atlassian.io/jira-software-cloud/issues/search#search-for-issues-using-jql-get
 //
 // Deprecated: This endpoint will be removed after May 1, 2025. Use SearchJQL, BulkFetch and ApproximateCount instead.
-// TODO: Implementation still uses deprecated POST /rest/api/3/search endpoint.
-// Cannot change without breaking API compatibility. Consider removing in next major version.
+// TODO Cannot change without breaking API compatibility. Consider removing in next major version.
 func (s *SearchADFService) Post(ctx context.Context, jql string, fields, expands []string, startAt, maxResults int, validate string) (*model.IssueSearchScheme, *model.ResponseScheme, error) {
 	return s.internalClient.Post(ctx, jql, fields, expands, startAt, maxResults, validate)
 }

--- a/jira/internal/search_impl_adf.go
+++ b/jira/internal/search_impl_adf.go
@@ -35,6 +35,8 @@ func (s *SearchADFService) Checks(ctx context.Context, payload *model.IssueSearc
 // https://docs.go-atlassian.io/jira-software-cloud/issues/search#search-for-issues-using-jql-get
 //
 // Deprecated: This endpoint will be removed after May 1, 2025. Use SearchJQL, BulkFetch and ApproximateCount instead.
+// TODO: Implementation still uses deprecated GET /rest/api/3/search endpoint.
+// Cannot change without breaking API compatibility. Consider removing in next major version.
 func (s *SearchADFService) Get(ctx context.Context, jql string, fields, expands []string, startAt, maxResults int, validate string) (*model.IssueSearchScheme, *model.ResponseScheme, error) {
 	return s.internalClient.Get(ctx, jql, fields, expands, startAt, maxResults, validate)
 }
@@ -46,6 +48,8 @@ func (s *SearchADFService) Get(ctx context.Context, jql string, fields, expands 
 // https://docs.go-atlassian.io/jira-software-cloud/issues/search#search-for-issues-using-jql-get
 //
 // Deprecated: This endpoint will be removed after May 1, 2025. Use SearchJQL, BulkFetch and ApproximateCount instead.
+// TODO: Implementation still uses deprecated POST /rest/api/3/search endpoint.
+// Cannot change without breaking API compatibility. Consider removing in next major version.
 func (s *SearchADFService) Post(ctx context.Context, jql string, fields, expands []string, startAt, maxResults int, validate string) (*model.IssueSearchScheme, *model.ResponseScheme, error) {
 	return s.internalClient.Post(ctx, jql, fields, expands, startAt, maxResults, validate)
 }
@@ -170,6 +174,8 @@ func (i *internalSearchADFImpl) Post(ctx context.Context, jql string, fields, ex
 // SearchJQL searches issues using the new JQL search endpoint
 //
 // POST /rest/api/3/search/jql
+// TODO: Missing optional parameters from API spec: properties, fieldsByKeys, failFast, reconcileIssues
+// Cannot add without breaking API compatibility. Consider adding in next major version.
 func (i *internalSearchADFImpl) SearchJQL(ctx context.Context, jql string, fields, expands []string, maxResults int, nextPageToken string) (*model.IssueSearchJQLScheme, *model.ResponseScheme, error) {
 
 	payload := struct {

--- a/jira/internal/search_impl_rich_text.go
+++ b/jira/internal/search_impl_rich_text.go
@@ -35,8 +35,7 @@ func (s *SearchRichTextService) Checks(ctx context.Context, payload *model.Issue
 // https://docs.go-atlassian.io/jira-software-cloud/issues/search#search-for-issues-using-jql-get
 //
 // Deprecated: This endpoint will be removed after May 1, 2025. Use SearchJQL, BulkFetch and ApproximateCount instead.
-// TODO: Implementation still uses deprecated GET /rest/api/2/search endpoint.
-// Cannot change without breaking API compatibility. Consider removing in next major version.
+// TODO Cannot change without breaking API compatibility. Consider removing in next major version.
 func (s *SearchRichTextService) Get(ctx context.Context, jql string, fields, expands []string, startAt, maxResults int, validate string) (*model.IssueSearchSchemeV2, *model.ResponseScheme, error) {
 	return s.internalClient.Get(ctx, jql, fields, expands, startAt, maxResults, validate)
 }
@@ -48,8 +47,7 @@ func (s *SearchRichTextService) Get(ctx context.Context, jql string, fields, exp
 // https://docs.go-atlassian.io/jira-software-cloud/issues/search#search-for-issues-using-jql-get
 //
 // Deprecated: This endpoint will be removed after May 1, 2025. Use SearchJQL, BulkFetch and ApproximateCount instead.
-// TODO: Implementation still uses deprecated POST /rest/api/2/search endpoint.
-// Cannot change without breaking API compatibility. Consider removing in next major version.
+// TODO Cannot change without breaking API compatibility. Consider removing in next major version.
 func (s *SearchRichTextService) Post(ctx context.Context, jql string, fields, expands []string, startAt, maxResults int, validate string) (*model.IssueSearchSchemeV2, *model.ResponseScheme, error) {
 	return s.internalClient.Post(ctx, jql, fields, expands, startAt, maxResults, validate)
 }

--- a/jira/internal/search_impl_rich_text.go
+++ b/jira/internal/search_impl_rich_text.go
@@ -35,6 +35,8 @@ func (s *SearchRichTextService) Checks(ctx context.Context, payload *model.Issue
 // https://docs.go-atlassian.io/jira-software-cloud/issues/search#search-for-issues-using-jql-get
 //
 // Deprecated: This endpoint will be removed after May 1, 2025. Use SearchJQL, BulkFetch and ApproximateCount instead.
+// TODO: Implementation still uses deprecated GET /rest/api/2/search endpoint.
+// Cannot change without breaking API compatibility. Consider removing in next major version.
 func (s *SearchRichTextService) Get(ctx context.Context, jql string, fields, expands []string, startAt, maxResults int, validate string) (*model.IssueSearchSchemeV2, *model.ResponseScheme, error) {
 	return s.internalClient.Get(ctx, jql, fields, expands, startAt, maxResults, validate)
 }
@@ -46,6 +48,8 @@ func (s *SearchRichTextService) Get(ctx context.Context, jql string, fields, exp
 // https://docs.go-atlassian.io/jira-software-cloud/issues/search#search-for-issues-using-jql-get
 //
 // Deprecated: This endpoint will be removed after May 1, 2025. Use SearchJQL, BulkFetch and ApproximateCount instead.
+// TODO: Implementation still uses deprecated POST /rest/api/2/search endpoint.
+// Cannot change without breaking API compatibility. Consider removing in next major version.
 func (s *SearchRichTextService) Post(ctx context.Context, jql string, fields, expands []string, startAt, maxResults int, validate string) (*model.IssueSearchSchemeV2, *model.ResponseScheme, error) {
 	return s.internalClient.Post(ctx, jql, fields, expands, startAt, maxResults, validate)
 }
@@ -170,6 +174,8 @@ func (i *internalSearchRichTextImpl) Post(ctx context.Context, jql string, field
 // SearchJQL searches issues using the new JQL search endpoint
 //
 // POST /rest/api/2/search/jql
+// TODO: Missing optional parameters from API spec: properties, fieldsByKeys, failFast, reconcileIssues
+// Cannot add without breaking API compatibility. Consider adding in next major version.
 func (i *internalSearchRichTextImpl) SearchJQL(ctx context.Context, jql string, fields, expands []string, maxResults int, nextPageToken string) (*model.IssueSearchJQLSchemeV2, *model.ResponseScheme, error) {
 
 	payload := struct {

--- a/pkg/infra/models/jira_changelog.go
+++ b/pkg/infra/models/jira_changelog.go
@@ -12,7 +12,7 @@ type IssueChangelogScheme struct {
 type IssueChangelogHistoryScheme struct {
 	ID      string                             `json:"id,omitempty"`      // The ID of the history.
 	Author  *IssueChangelogAuthor              `json:"author,omitempty"`  // The author of the history.
-	Created string                             `json:"created,omitempty"` // The creation time of the history.
+	Created string                             `json:"created,omitempty"` // The creation time of the history. TODO: Should use *DateTimeScheme for proper RFC3339 formatting. Cannot change without breaking API compatibility.
 	Items   []*IssueChangelogHistoryItemScheme `json:"items,omitempty"`   // The items in the history.
 }
 

--- a/pkg/infra/models/jira_comment_v2.go
+++ b/pkg/infra/models/jira_comment_v2.go
@@ -17,8 +17,8 @@ type IssueCommentSchemeV2 struct {
 	Author       *UserScheme              `json:"author,omitempty"`       // The author of the comment.
 	JSDPublic    bool                     `json:"jsdPublic,omitempty"`    // Indicates if the comment is public in Jira Service Desk.
 	UpdateAuthor *UserScheme              `json:"updateAuthor,omitempty"` // The user who last updated the comment.
-	Created      string                   `json:"created,omitempty"`      // The creation time of the comment.
-	Updated      string                   `json:"updated,omitempty"`      // The last update time of the comment.
+	Created      string                   `json:"created,omitempty"`      // The creation time of the comment. TODO: Should use *DateTimeScheme for proper RFC3339 formatting. Cannot change without breaking API compatibility.
+	Updated      string                   `json:"updated,omitempty"`      // The last update time of the comment. TODO: Should use *DateTimeScheme for proper RFC3339 formatting. Cannot change without breaking API compatibility.
 	Visibility   *CommentVisibilityScheme `json:"visibility,omitempty"`   // The visibility of the comment.
 }
 

--- a/pkg/infra/models/jira_comment_v3.go
+++ b/pkg/infra/models/jira_comment_v3.go
@@ -45,8 +45,8 @@ type IssueCommentScheme struct {
 	Body         *CommentNodeScheme       `json:"body,omitempty"`         // The body of the comment.
 	JSDPublic    bool                     `json:"jsdPublic,omitempty"`    // Whether the comment is public.
 	UpdateAuthor *UserScheme              `json:"updateAuthor,omitempty"` // The author of the last update.
-	Created      string                   `json:"created,omitempty"`      // The creation time of the comment.
-	Updated      string                   `json:"updated,omitempty"`      // The last update time of the comment.
+	Created      string                   `json:"created,omitempty"`      // The creation time of the comment. TODO: Should use *DateTimeScheme for proper RFC3339 formatting. Cannot change without breaking API compatibility.
+	Updated      string                   `json:"updated,omitempty"`      // The last update time of the comment. TODO: Should use *DateTimeScheme for proper RFC3339 formatting. Cannot change without breaking API compatibility.
 	Visibility   *CommentVisibilityScheme `json:"visibility,omitempty"`   // The visibility of the comment.
 }
 

--- a/pkg/infra/models/jira_issue_attachments.go
+++ b/pkg/infra/models/jira_issue_attachments.go
@@ -12,8 +12,8 @@ type IssueAttachmentScheme struct {
 	ID        string      `json:"id,omitempty"`        // The ID of the attachment.
 	Filename  string      `json:"filename,omitempty"`  // The filename of the attachment.
 	Author    *UserScheme `json:"author,omitempty"`    // The author of the attachment.
-	Created   string      `json:"created,omitempty"`   // The creation time of the attachment. TODO: Should use *DateTimeScheme for proper RFC3339 formatting. Cannot change without breaking API compatibility.
-	Size      int64       `json:"size,omitempty"`      // The size of the attachment.
+	Created   string      `json:"created,omitempty"`   // The creation time of the attachment.
+	Size      int         `json:"size,omitempty"`      // The size of the attachment.
 	MimeType  string      `json:"mimeType,omitempty"`  // The MIME type of the attachment.
 	Content   string      `json:"content,omitempty"`   // The content of the attachment.
 	Thumbnail string      `json:"thumbnail,omitempty"` // The thumbnail of the attachment.
@@ -25,8 +25,8 @@ type IssueAttachmentMetadataScheme struct {
 	Self      string      `json:"self,omitempty"`      // The URL of the attachment.
 	Filename  string      `json:"filename,omitempty"`  // The filename of the attachment.
 	Author    *UserScheme `json:"author,omitempty"`    // The author of the attachment.
-	Created   string      `json:"created,omitempty"`   // The creation time of the attachment. TODO: Should use *DateTimeScheme for proper RFC3339 formatting. Cannot change without breaking API compatibility.
-	Size      int64       `json:"size,omitempty"`      // The size of the attachment.
+	Created   string      `json:"created,omitempty"`   // The creation time of the attachment.
+	Size      int         `json:"size,omitempty"`      // The size of the attachment.
 	MimeType  string      `json:"mimeType,omitempty"`  // The MIME type of the attachment.
 	Content   string      `json:"content,omitempty"`   // The content of the attachment.
 	Thumbnail string      `json:"thumbnail,omitempty"` // The thumbnail of the attachment.

--- a/pkg/infra/models/jira_issue_attachments.go
+++ b/pkg/infra/models/jira_issue_attachments.go
@@ -12,7 +12,7 @@ type IssueAttachmentScheme struct {
 	ID        string      `json:"id,omitempty"`        // The ID of the attachment.
 	Filename  string      `json:"filename,omitempty"`  // The filename of the attachment.
 	Author    *UserScheme `json:"author,omitempty"`    // The author of the attachment.
-	Created   string      `json:"created,omitempty"`   // The creation time of the attachment.
+	Created   string      `json:"created,omitempty"`   // The creation time of the attachment. TODO: Should use *DateTimeScheme for proper RFC3339 formatting. Cannot change without breaking API compatibility.
 	Size      int         `json:"size,omitempty"`      // The size of the attachment.
 	MimeType  string      `json:"mimeType,omitempty"`  // The MIME type of the attachment.
 	Content   string      `json:"content,omitempty"`   // The content of the attachment.
@@ -25,7 +25,7 @@ type IssueAttachmentMetadataScheme struct {
 	Self      string      `json:"self,omitempty"`      // The URL of the attachment.
 	Filename  string      `json:"filename,omitempty"`  // The filename of the attachment.
 	Author    *UserScheme `json:"author,omitempty"`    // The author of the attachment.
-	Created   string      `json:"created,omitempty"`   // The creation time of the attachment.
+	Created   string      `json:"created,omitempty"`   // The creation time of the attachment. TODO: Should use *DateTimeScheme for proper RFC3339 formatting. Cannot change without breaking API compatibility.
 	Size      int         `json:"size,omitempty"`      // The size of the attachment.
 	MimeType  string      `json:"mimeType,omitempty"`  // The MIME type of the attachment.
 	Content   string      `json:"content,omitempty"`   // The content of the attachment.

--- a/pkg/infra/models/jira_issue_attachments.go
+++ b/pkg/infra/models/jira_issue_attachments.go
@@ -12,8 +12,8 @@ type IssueAttachmentScheme struct {
 	ID        string      `json:"id,omitempty"`        // The ID of the attachment.
 	Filename  string      `json:"filename,omitempty"`  // The filename of the attachment.
 	Author    *UserScheme `json:"author,omitempty"`    // The author of the attachment.
-	Created   string      `json:"created,omitempty"`   // The creation time of the attachment.
-	Size      int         `json:"size,omitempty"`      // The size of the attachment.
+	Created   string      `json:"created,omitempty"`   // The creation time of the attachment. TODO: Should use *DateTimeScheme for proper RFC3339 formatting. Cannot change without breaking API compatibility.
+	Size      int64       `json:"size,omitempty"`      // The size of the attachment.
 	MimeType  string      `json:"mimeType,omitempty"`  // The MIME type of the attachment.
 	Content   string      `json:"content,omitempty"`   // The content of the attachment.
 	Thumbnail string      `json:"thumbnail,omitempty"` // The thumbnail of the attachment.
@@ -25,8 +25,8 @@ type IssueAttachmentMetadataScheme struct {
 	Self      string      `json:"self,omitempty"`      // The URL of the attachment.
 	Filename  string      `json:"filename,omitempty"`  // The filename of the attachment.
 	Author    *UserScheme `json:"author,omitempty"`    // The author of the attachment.
-	Created   string      `json:"created,omitempty"`   // The creation time of the attachment.
-	Size      int         `json:"size,omitempty"`      // The size of the attachment.
+	Created   string      `json:"created,omitempty"`   // The creation time of the attachment. TODO: Should use *DateTimeScheme for proper RFC3339 formatting. Cannot change without breaking API compatibility.
+	Size      int64       `json:"size,omitempty"`      // The size of the attachment.
 	MimeType  string      `json:"mimeType,omitempty"`  // The MIME type of the attachment.
 	Content   string      `json:"content,omitempty"`   // The content of the attachment.
 	Thumbnail string      `json:"thumbnail,omitempty"` // The thumbnail of the attachment.

--- a/service/jira/metadata.go
+++ b/service/jira/metadata.go
@@ -27,7 +27,7 @@ type MetadataConnector interface {
 	//
 	// https://docs.go-atlassian.io/jira-software-cloud/issues/metadata#get-create-issue-metadata
 	// Deprecated: This endpoint is deprecated in the Jira API spec.
-	// TODO Cannot change without breaking API compatibility. Consider removing in next major version.
+	// TODO: Cannot change without breaking API compatibility. Consider removing in next major version.
 	Create(ctx context.Context, opts *model.IssueMetadataCreateOptions) (gjson.Result, *model.ResponseScheme, error)
 
 	// FetchIssueMappings returns a page of issue type metadata for a specified project.

--- a/service/jira/metadata.go
+++ b/service/jira/metadata.go
@@ -26,6 +26,8 @@ type MetadataConnector interface {
 	// GET /rest/api/{2-3}/issue/createmeta
 	//
 	// https://docs.go-atlassian.io/jira-software-cloud/issues/metadata#get-create-issue-metadata
+	// Deprecated: This endpoint is deprecated in the Jira API spec.
+	// TODO Cannot change without breaking API compatibility. Consider removing in next major version.
 	Create(ctx context.Context, opts *model.IssueMetadataCreateOptions) (gjson.Result, *model.ResponseScheme, error)
 
 	// FetchIssueMappings returns a page of issue type metadata for a specified project.

--- a/service/jira/priority.go
+++ b/service/jira/priority.go
@@ -14,7 +14,7 @@ type PriorityConnector interface {
 	//
 	// https://docs.go-atlassian.io/jira-software-cloud/issues/priorities#get-priorities
 	// Deprecated: This endpoint is deprecated in the Jira API spec.
-	// TODO Cannot change without breaking API compatibility. Consider removing in next major version.
+	// TODO: Cannot change without breaking API compatibility. Consider removing in next major version.
 	Gets(ctx context.Context) ([]*model.PriorityScheme, *model.ResponseScheme, error)
 
 	// Get returns an issue priority.

--- a/service/jira/priority.go
+++ b/service/jira/priority.go
@@ -13,6 +13,8 @@ type PriorityConnector interface {
 	// GET /rest/api/{2-3}/priority
 	//
 	// https://docs.go-atlassian.io/jira-software-cloud/issues/priorities#get-priorities
+	// Deprecated: This endpoint is deprecated in the Jira API spec.
+	// TODO Cannot change without breaking API compatibility. Consider removing in next major version.
 	Gets(ctx context.Context) ([]*model.PriorityScheme, *model.ResponseScheme, error)
 
 	// Get returns an issue priority.
@@ -20,5 +22,7 @@ type PriorityConnector interface {
 	// GET /rest/api/{2-3}/priority/{priorityID}
 	//
 	// https://docs.go-atlassian.io/jira-software-cloud/issues/priorities#get-priority
+	// Deprecated: This endpoint is deprecated in the Jira API spec.
+	// TODO Cannot change without breaking API compatibility. Consider removing in next major version.
 	Get(ctx context.Context, priorityID string) (*model.PriorityScheme, *model.ResponseScheme, error)
 }


### PR DESCRIPTION
This pull request includes several updates to the Jira API client to address deprecated endpoints, missing parameters, and data type improvements. These changes primarily involve adding TODO comments to document areas for future improvement while maintaining backward compatibility in the current version. Below is a summary of the most important changes grouped by theme:

### Deprecation Notices for Endpoints:
* Added deprecation notices for the `Get` and `Post` methods in `SearchADFService` and `SearchRichTextService`, as these endpoints are scheduled for removal after May 1, 2025. Suggested alternatives include `SearchJQL`, `BulkFetch`, and `ApproximateCount` methods. [[1]](diffhunk://#diff-5bf058e6cede7f34d445fa1d2c4b6ef232123e7db2798c6b5422cf5a985df330R38) [[2]](diffhunk://#diff-5bf058e6cede7f34d445fa1d2c4b6ef232123e7db2798c6b5422cf5a985df330R50) [[3]](diffhunk://#diff-81689f98aedf8d01fd6b56bebdab18325c45c45569c4a7a105938a2197faf2f9R38) [[4]](diffhunk://#diff-81689f98aedf8d01fd6b56bebdab18325c45c45569c4a7a105938a2197faf2f9R50)
* Marked the `Create` method in `MetadataService` and the `Gets` and `Get` methods in `PriorityService` as deprecated according to the Jira API spec. These methods are flagged for potential removal in the next major version. [[1]](diffhunk://#diff-889361568270206d87247f7c4106d488e6a67510010feba8959dfe838a5f4b5dR57-R58) [[2]](diffhunk://#diff-dfff0056fe13936ab347c089de68bebd34972fb63e974efb11e93075de7a6aa5R36-R37) [[3]](diffhunk://#diff-dfff0056fe13936ab347c089de68bebd34972fb63e974efb11e93075de7a6aa5R47-R48) [[4]](diffhunk://#diff-047c818183828edac50451d011e859854728ec183713f7119b92a9c2e319bedaR29-R30) [[5]](diffhunk://#diff-ba3854cde2ac8315d5da81f79c9a6e7d6e210217d0ce45f76a28cd2009a538d2R16-R26)

### Missing Parameters in API Methods:
* Documented missing optional parameters (`updateHistory`, `properties`, `fieldsByKeys`, `failFast`, and `reconcileIssues`) in several API methods, such as `Create` in `internalIssueADFServiceImpl` and `SearchJQL` in `internalSearchADFImpl` and `internalSearchRichTextImpl`. These parameters cannot be added without breaking API compatibility and are planned for inclusion in the next major version. [[1]](diffhunk://#diff-00287e1366baed5c197dcb6aaeb34e11948449acb94bd16aed89b5224c32b5e4R202-R204) [[2]](diffhunk://#diff-ed80445d9119a0f98bdd8d24560f35e639b6d1b2b6916c1248ae4409918c48aeR202-R204) [[3]](diffhunk://#diff-5bf058e6cede7f34d445fa1d2c4b6ef232123e7db2798c6b5422cf5a985df330R175-R176) [[4]](diffhunk://#diff-81689f98aedf8d01fd6b56bebdab18325c45c45569c4a7a105938a2197faf2f9R175-R176)

### Data Type Improvements:
* Added TODO comments to suggest replacing `string` with `*DateTimeScheme` for `Created` and `Updated` fields in changelog and comment models (`IssueChangelogScheme`, `IssueCommentSchemeV2`, and `IssueCommentScheme`). This change would ensure proper RFC3339 formatting but requires a major version update to avoid breaking compatibility. [[1]](diffhunk://#diff-eb082d6241bc42d01050cc9534c6a05704baff37c7d735c399ea6eba58bb425cL15-R15) [[2]](diffhunk://#diff-7bdf8532da382cc9079e128969dcf32ee5a545302c75054ae1a06eaafcfcb198L20-R21) [[3]](diffhunk://#diff-f98bf926ddbdc03c56986945ce5227408e8d98a6b30146a836656e495aec6fdfL48-R49)

### Minor Fixes:
* Corrected the endpoint URL in the `Get` method of `ProjectService` to include a missing forward slash. This change aligns the implementation with the API documentation.