### PR TITLE
Added predefine account types

### DIFF
--- a/pkg/infra/models/jira_user.go
+++ b/pkg/infra/models/jira_user.go
@@ -1,5 +1,13 @@
 package models
 
+// User account type constants
+const (
+	UserAccountTypeAtlassian = "atlassian"
+	UserAccountTypeApp       = "app"
+	UserAccountTypeCustomer  = "customer"
+	UserAccountTypeUnknown   = "unknown"
+)
+
 // UserScheme represents a user in Jira.
 type UserScheme struct {
 	Self             string                      `json:"self,omitempty"`             // The URL of the user.


### PR DESCRIPTION
This pull request introduces a new set of constants to represent different user account types in the `pkg/infra/models/jira_user.go` file. These constants will help standardize the representation of user account types in the codebase.

Key change:

* [`pkg/infra/models/jira_user.go`](diffhunk://#diff-71bb2403369d798e2bca5220d01b2c13a3de44b1ddc8088b20b288bf29d3a33cR3-R10): Added constants `UserAccountTypeAtlassian`, `UserAccountTypeApp`, `UserAccountTypeCustomer`, and `UserAccountTypeUnknown` to define user account types in Jira.