### PR TITLE
Fixed attachement file size type

### DIFF
--- a/pkg/infra/models/jira_issue_attachments.go
+++ b/pkg/infra/models/jira_issue_attachments.go
@@ -13,7 +13,7 @@ type IssueAttachmentScheme struct {
 	Filename  string      `json:"filename,omitempty"`  // The filename of the attachment.
 	Author    *UserScheme `json:"author,omitempty"`    // The author of the attachment.
 	Created   string      `json:"created,omitempty"`   // The creation time of the attachment.
-	Size      int         `json:"size,omitempty"`      // The size of the attachment.
+	Size      int64       `json:"size,omitempty"`      // The size of the attachment.
 	MimeType  string      `json:"mimeType,omitempty"`  // The MIME type of the attachment.
 	Content   string      `json:"content,omitempty"`   // The content of the attachment.
 	Thumbnail string      `json:"thumbnail,omitempty"` // The thumbnail of the attachment.
@@ -26,7 +26,7 @@ type IssueAttachmentMetadataScheme struct {
 	Filename  string      `json:"filename,omitempty"`  // The filename of the attachment.
 	Author    *UserScheme `json:"author,omitempty"`    // The author of the attachment.
 	Created   string      `json:"created,omitempty"`   // The creation time of the attachment.
-	Size      int         `json:"size,omitempty"`      // The size of the attachment.
+	Size      int64       `json:"size,omitempty"`      // The size of the attachment.
 	MimeType  string      `json:"mimeType,omitempty"`  // The MIME type of the attachment.
 	Content   string      `json:"content,omitempty"`   // The content of the attachment.
 	Thumbnail string      `json:"thumbnail,omitempty"` // The thumbnail of the attachment.


### PR DESCRIPTION
This pull request updates the data type for the `Size` field in two structs within the `pkg/infra/models/jira_issue_attachments.go` file to ensure compatibility with larger attachment sizes.

Changes to field types:

* [`pkg/infra/models/jira_issue_attachments.go`](diffhunk://#diff-bba7a9a596b79d31d215311ec3bc613519058f44c4c9f874d510156f2575295bL16-R16): Updated the `Size` field in the `IssueAttachmentScheme` struct from `int` to `int64` to support larger attachment sizes.
* [`pkg/infra/models/jira_issue_attachments.go`](diffhunk://#diff-bba7a9a596b79d31d215311ec3bc613519058f44c4c9f874d510156f2575295bL29-R29): Updated the `Size` field in the `IssueAttachmentMetadataScheme` struct from `int` to `int64` for consistency and to support larger attachment sizes.