### PR TITLE
fix: correct SearchJQL expand field type from []string to string

### DIFF
--- a/jira/internal/search_impl_adf.go
+++ b/jira/internal/search_impl_adf.go
@@ -180,13 +180,13 @@ func (i *internalSearchADFImpl) SearchJQL(ctx context.Context, jql string, field
 		Jql           string   `json:"jql,omitempty"`
 		MaxResults    int      `json:"maxResults,omitempty"`
 		Fields        []string `json:"fields,omitempty"`
-		Expand        []string `json:"expand,omitempty"`
+		Expand        string   `json:"expand,omitempty"`
 		NextPageToken string   `json:"nextPageToken,omitempty"`
 	}{
 		Jql:           jql,
 		MaxResults:    maxResults,
 		Fields:        fields,
-		Expand:        expands,
+		Expand:        strings.Join(expands, ","),
 		NextPageToken: nextPageToken,
 	}
 

--- a/jira/internal/search_impl_adf_test.go
+++ b/jira/internal/search_impl_adf_test.go
@@ -534,13 +534,13 @@ func Test_internalSearchADFImpl_SearchJQL(t *testing.T) {
 					Jql           string   `json:"jql,omitempty"`
 					MaxResults    int      `json:"maxResults,omitempty"`
 					Fields        []string `json:"fields,omitempty"`
-					Expand        []string `json:"expand,omitempty"`
+					Expand        string   `json:"expand,omitempty"`
 					NextPageToken string   `json:"nextPageToken,omitempty"`
 				}{
 					Jql:           "project = FOO",
 					MaxResults:    50,
 					Fields:        []string{"summary", "status"},
-					Expand:        []string{"changelog", "names"},
+					Expand:        "changelog,names",
 					NextPageToken: "CAEaAggD",
 				}
 
@@ -581,13 +581,13 @@ func Test_internalSearchADFImpl_SearchJQL(t *testing.T) {
 					Jql           string   `json:"jql,omitempty"`
 					MaxResults    int      `json:"maxResults,omitempty"`
 					Fields        []string `json:"fields,omitempty"`
-					Expand        []string `json:"expand,omitempty"`
+					Expand        string   `json:"expand,omitempty"`
 					NextPageToken string   `json:"nextPageToken,omitempty"`
 				}{
 					Jql:           "project = FOO",
 					MaxResults:    50,
 					Fields:        []string{"summary", "status"},
-					Expand:        []string{"changelog", "names"},
+					Expand:        "changelog,names",
 					NextPageToken: "CAEaAggD",
 				}
 

--- a/jira/internal/search_impl_rich_text.go
+++ b/jira/internal/search_impl_rich_text.go
@@ -180,13 +180,13 @@ func (i *internalSearchRichTextImpl) SearchJQL(ctx context.Context, jql string, 
 		Jql           string   `json:"jql,omitempty"`
 		MaxResults    int      `json:"maxResults,omitempty"`
 		Fields        []string `json:"fields,omitempty"`
-		Expand        []string `json:"expand,omitempty"`
+		Expand        string   `json:"expand,omitempty"`
 		NextPageToken string   `json:"nextPageToken,omitempty"`
 	}{
 		Jql:           jql,
 		MaxResults:    maxResults,
 		Fields:        fields,
-		Expand:        expands,
+		Expand:        strings.Join(expands, ","),
 		NextPageToken: nextPageToken,
 	}
 

--- a/jira/internal/search_impl_rich_text_test.go
+++ b/jira/internal/search_impl_rich_text_test.go
@@ -534,13 +534,13 @@ func Test_internalSearchRichTextImpl_SearchJQL(t *testing.T) {
 					Jql           string   `json:"jql,omitempty"`
 					MaxResults    int      `json:"maxResults,omitempty"`
 					Fields        []string `json:"fields,omitempty"`
-					Expand        []string `json:"expand,omitempty"`
+					Expand        string   `json:"expand,omitempty"`
 					NextPageToken string   `json:"nextPageToken,omitempty"`
 				}{
 					Jql:           "project = FOO",
 					MaxResults:    50,
 					Fields:        []string{"summary", "status"},
-					Expand:        []string{"changelog", "names"},
+					Expand:        "changelog,names",
 					NextPageToken: "CAEaAggD",
 				}
 
@@ -581,13 +581,13 @@ func Test_internalSearchRichTextImpl_SearchJQL(t *testing.T) {
 					Jql           string   `json:"jql,omitempty"`
 					MaxResults    int      `json:"maxResults,omitempty"`
 					Fields        []string `json:"fields,omitempty"`
-					Expand        []string `json:"expand,omitempty"`
+					Expand        string   `json:"expand,omitempty"`
 					NextPageToken string   `json:"nextPageToken,omitempty"`
 				}{
 					Jql:           "project = FOO",
 					MaxResults:    50,
 					Fields:        []string{"summary", "status"},
-					Expand:        []string{"changelog", "names"},
+					Expand:        "changelog,names",
 					NextPageToken: "CAEaAggD",
 				}
 


### PR DESCRIPTION
## Summary
- Fixed the `expand` field type in SearchJQL API from `[]string` to `string` to match Jira REST API requirements
- Applied fix to both v2 and v3 implementations
- Updated corresponding tests to match the new payload structure

## Details
The SearchJQL API was sending the expand parameter as a JSON array when the Jira REST API expects it to be a string. This was causing requests to fail with "Invalid request payload" errors.

### Changes made:
1. Changed the `Expand` field type from `[]string` to `string` in the request payload structs
2. Used `strings.Join(expands, ",")` to convert the expands slice to a comma-separated string
3. Updated tests to expect the new payload structure

## Test Results
All tests are passing:
```
=== RUN   Test_internalSearchADFImpl_SearchJQL
--- PASS: Test_internalSearchADFImpl_SearchJQL (0.00s)
    --- PASS: Test_internalSearchADFImpl_SearchJQL/when_the_search_jql_operation_is_successful (0.00s)
    --- PASS: Test_internalSearchADFImpl_SearchJQL/when_the_request_returns_an_error (0.00s)
=== RUN   Test_internalSearchRichTextImpl_SearchJQL
--- PASS: Test_internalSearchRichTextImpl_SearchJQL (0.00s)
    --- PASS: Test_internalSearchRichTextImpl_SearchJQL/when_the_search_jql_operation_is_successful (0.00s)
    --- PASS: Test_internalSearchRichTextImpl_SearchJQL/when_the_request_returns_an_error (0.00s)
```

Fixes #370

🤖 Generated with [Claude Code](https://claude.ai/code)