### PR TITLE
fix: Project.Component.Gets always returns nil (#400)

### DIFF
--- a/jira/internal/project_component_impl.go
+++ b/jira/internal/project_component_impl.go
@@ -121,7 +121,7 @@ func (i *internalProjectComponentImpl) Gets(ctx context.Context, projectKeyOrID 
 	}
 
 	var components []*model.ComponentScheme
-	response, err := i.c.Call(request, components)
+	response, err := i.c.Call(request, &components)
 	if err != nil {
 		return nil, response, err
 	}


### PR DESCRIPTION
## Summary
- Fixes #400 where `Project.Component.Gets()` was always returning nil even when components exist
- The issue was caused by passing the slice by value instead of by reference to the `Call` method

## Root Cause
The `Gets` method was calling `i.c.Call(request, components)` instead of `i.c.Call(request, &components)`. This caused JSON unmarshaling to fail silently, leaving the slice as nil.

## Fix
Changed line 124 in `jira/internal/project_component_impl.go`:
```diff
- response, err := i.c.Call(request, components)
+ response, err := i.c.Call(request, &components)
```

## Test Plan
- [x] Verified existing tests pass
- [x] The pattern matches other similar implementations in the codebase that correctly use `&` for slice parameters
- [ ] Manual testing with a real Jira instance to confirm components are returned

## Notes
This is a minimal fix that addresses the immediate issue. The same pattern is used correctly in 30+ other places in the codebase (e.g., `project_category_impl.go:91`, `workflow_status_impl.go:142`, etc.).