### PR TITLE
fix: pass pointers to slices in Call methods for filter operations

### DIFF
--- a/jira/internal/filter_impl.go
+++ b/jira/internal/filter_impl.go
@@ -145,7 +145,7 @@ func (i *internalFilterServiceImpl) Favorite(ctx context.Context) ([]*model.Filt
 	}
 
 	var filters []*model.FilterScheme
-	response, err := i.c.Call(request, filters)
+	response, err := i.c.Call(request, &filters)
 	if err != nil {
 		return nil, response, err
 	}
@@ -170,7 +170,7 @@ func (i *internalFilterServiceImpl) My(ctx context.Context, favorites bool, expa
 	}
 
 	var filters []*model.FilterScheme
-	response, err := i.c.Call(request, filters)
+	response, err := i.c.Call(request, &filters)
 	if err != nil {
 		return nil, response, err
 	}

--- a/jira/internal/filter_impl_test.go
+++ b/jira/internal/filter_impl_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 
 	model "github.com/ctreminiom/go-atlassian/v2/pkg/infra/models"
 	"github.com/ctreminiom/go-atlassian/v2/service"
@@ -205,7 +206,7 @@ func TestFilterService_Favorite(t *testing.T) {
 
 				client.On("Call",
 					&http.Request{},
-					[]*model.FilterScheme(nil)).
+					mock.Anything).
 					Return(&model.ResponseScheme{}, nil)
 
 				fields.c = client
@@ -233,7 +234,7 @@ func TestFilterService_Favorite(t *testing.T) {
 
 				client.On("Call",
 					&http.Request{},
-					[]*model.FilterScheme(nil)).
+					mock.Anything).
 					Return(&model.ResponseScheme{}, nil)
 
 				fields.c = client
@@ -349,7 +350,7 @@ func TestFilterService_My(t *testing.T) {
 
 				client.On("Call",
 					&http.Request{},
-					[]*model.FilterScheme(nil)).
+					mock.Anything).
 					Return(&model.ResponseScheme{}, nil)
 
 				fields.c = client
@@ -379,7 +380,7 @@ func TestFilterService_My(t *testing.T) {
 
 				client.On("Call",
 					&http.Request{},
-					[]*model.FilterScheme(nil)).
+					mock.Anything).
 					Return(&model.ResponseScheme{}, nil)
 
 				fields.c = client

--- a/jira/internal/filter_share_impl.go
+++ b/jira/internal/filter_share_impl.go
@@ -145,7 +145,7 @@ func (i *internalFilterShareImpl) Gets(ctx context.Context, filterID int) ([]*mo
 	}
 
 	var filters []*model.SharePermissionScheme
-	response, err := i.c.Call(request, filters)
+	response, err := i.c.Call(request, &filters)
 	if err != nil {
 		return nil, response, err
 	}
@@ -167,7 +167,7 @@ func (i *internalFilterShareImpl) Add(ctx context.Context, filterID int, payload
 	}
 
 	var permissions []*model.SharePermissionScheme
-	response, err := i.c.Call(request, permissions)
+	response, err := i.c.Call(request, &permissions)
 	if err != nil {
 		return nil, response, err
 	}

--- a/jira/internal/filter_share_impl_test.go
+++ b/jira/internal/filter_share_impl_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 
 	model "github.com/ctreminiom/go-atlassian/v2/pkg/infra/models"
 	"github.com/ctreminiom/go-atlassian/v2/service"
@@ -326,7 +327,7 @@ func TestFilterShareService_Gets(t *testing.T) {
 
 				client.On("Call",
 					&http.Request{},
-					[]*model.SharePermissionScheme(nil)).
+					mock.Anything).
 					Return(&model.ResponseScheme{}, nil)
 
 				fields.c = client
@@ -354,7 +355,7 @@ func TestFilterShareService_Gets(t *testing.T) {
 
 				client.On("Call",
 					&http.Request{},
-					[]*model.SharePermissionScheme(nil)).
+					mock.Anything).
 					Return(&model.ResponseScheme{}, nil)
 
 				fields.c = client
@@ -484,7 +485,7 @@ func TestFilterShareService_Add(t *testing.T) {
 
 				client.On("Call",
 					&http.Request{},
-					[]*model.SharePermissionScheme(nil)).
+					mock.Anything).
 					Return(&model.ResponseScheme{}, nil)
 
 				fields.c = client
@@ -513,7 +514,7 @@ func TestFilterShareService_Add(t *testing.T) {
 
 				client.On("Call",
 					&http.Request{},
-					[]*model.SharePermissionScheme(nil)).
+					mock.Anything).
 					Return(&model.ResponseScheme{}, nil)
 
 				fields.c = client


### PR DESCRIPTION
## Summary
- Fixes 4 additional instances of the same bug pattern as #400
- Slices were being passed by value instead of by reference to the `Call` method

## Issues Fixed
Fixed the following methods that were returning nil due to missing `&` operator:

### `jira/internal/filter_impl.go`
- `Favorite()` method (line 148) - `Call(request, filters)` → `Call(request, &filters)`  
- `My()` method (line 173) - `Call(request, filters)` → `Call(request, &filters)`

### `jira/internal/filter_share_impl.go`
- `Gets()` method (line 148) - `Call(request, filters)` → `Call(request, &filters)`
- `Add()` method (line 170) - `Call(request, permissions)` → `Call(request, &permissions)`

## Root Cause
Same as #400 - the slices were passed by value instead of by reference, causing JSON unmarshaling to fail silently and leave the slices as nil.

## Test Plan
- [x] Verified the pattern matches other correct implementations in the codebase
- [x] All existing tests pass
- [ ] Manual testing with a real Jira instance to confirm filters are returned properly

## Related
- Follows up on PR #401 which fixed the same issue in `Project.Component.Gets()`
- Part of a comprehensive fix for all similar issues in the codebase