### PR TITLE
feat(fields): add support for updating custom fields in Jira

### DIFF
--- a/pkg/infra/models/errors.go
+++ b/pkg/infra/models/errors.go
@@ -322,6 +322,9 @@ var (
 	// ErrNoFieldID indicates that a required field ID was not provided
 	ErrNoFieldID = errors.New("no field id set")
 
+	// ErrInvalidCustomFieldUpdate represents an error indicating the custom field update payload contains an invalid type attribute.
+	ErrInvalidCustomFieldUpdate = errors.New("invalid custom field update payload, type is not a valid attribute for update")
+
 	// ErrNoEditOperator indicates that a required update operation was not provided
 	ErrNoEditOperator = errors.New("no update operation set")
 

--- a/service/jira/field.go
+++ b/service/jira/field.go
@@ -31,6 +31,15 @@ type FieldConnector interface {
 	// https://docs.go-atlassian.io/jira-software-cloud/issues/fields#create-custom-field
 	Create(ctx context.Context, payload *model.CustomFieldScheme) (*model.IssueFieldScheme, *model.ResponseScheme, error)
 
+	// Update updates a custom field with the provided payload.
+	//
+	// PUT /rest/api/{2-3}/field/{id}
+	//
+	// Returns 204 No Content on success.
+	//
+	// https://docs.go-atlassian.io/jira-software-cloud/issues/fields#update-field
+	Update(ctx context.Context, fieldId string, payload *model.CustomFieldScheme) (*model.ResponseScheme, error)
+
 	// Search returns a paginated list of fields for Classic Jira projects.
 	//
 	// GET /rest/api/{2-3}/field/search


### PR DESCRIPTION
Introduced `Update` method in `IssueFieldService` to allow updating custom fields with validation for invalid payload attributes. Added corresponding error handling for invalid update payloads.