### PR TITLE
fix: correct schema field type in JQL search responses

### DIFF
--- a/pkg/infra/models/jira_issue_search.go
+++ b/pkg/infra/models/jira_issue_search.go
@@ -16,3 +16,9 @@ type IssueMatchesScheme struct {
 	MatchedIssues []int    `json:"matchedIssues,omitempty"` // The matched issues.
 	Errors        []string `json:"errors,omitempty"`        // The errors occurred during the matching process.
 }
+
+// IssueFieldSchema represents the schema information for a field in the JQL search response
+type IssueFieldSchema struct {
+	Type   string `json:"type"`
+	System string `json:"system"`
+}

--- a/pkg/infra/models/jira_search_v2.go
+++ b/pkg/infra/models/jira_search_v2.go
@@ -12,13 +12,13 @@ type IssueSearchSchemeV2 struct {
 
 // IssueSearchJQLSchemeV2 represents the response from the new JQL search endpoint for richtext (v2 API)
 type IssueSearchJQLSchemeV2 struct {
-	StartAt       int               `json:"startAt,omitempty"`
-	MaxResults    int               `json:"maxResults,omitempty"`
-	Total         int               `json:"total,omitempty"`
-	Issues        []*IssueSchemeV2  `json:"issues,omitempty"`
-	Names         map[string]string `json:"names,omitempty"`
-	Schema        map[string]string `json:"schema,omitempty"`
-	NextPageToken string            `json:"nextPageToken,omitempty"`
+	StartAt       int                          `json:"startAt,omitempty"`
+	MaxResults    int                          `json:"maxResults,omitempty"`
+	Total         int                          `json:"total,omitempty"`
+	Issues        []*IssueSchemeV2             `json:"issues,omitempty"`
+	Names         map[string]string            `json:"names,omitempty"`
+	Schema        map[string]*IssueFieldSchema `json:"schema,omitempty"`
+	NextPageToken string                       `json:"nextPageToken,omitempty"`
 }
 
 // IssueBulkFetchSchemeV2 represents the response from the bulk fetch endpoint for richtext (v2 API)

--- a/pkg/infra/models/jira_search_v2_test.go
+++ b/pkg/infra/models/jira_search_v2_test.go
@@ -1,0 +1,69 @@
+package models
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestIssueSearchJQLSchemeV2_SchemaUnmarshal(t *testing.T) {
+	// Test data that simulates the API response with expanded schema
+	testJSON := `{
+		"startAt": 0,
+		"maxResults": 10,
+		"total": 1,
+		"issues": [],
+		"schema": {
+			"summary": {
+				"type": "string",
+				"system": "summary"
+			},
+			"assignee": {
+				"type": "user",
+				"system": "assignee"
+			},
+			"status": {
+				"type": "status",
+				"system": "status"
+			}
+		}
+	}`
+
+	// Try to unmarshal into the V2 struct
+	var result IssueSearchJQLSchemeV2
+	err := json.Unmarshal([]byte(testJSON), &result)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal JSON: %v", err)
+	}
+
+	// Verify the schema was parsed correctly
+	if result.Schema == nil {
+		t.Fatal("Schema field is nil after unmarshaling")
+	}
+
+	// Check specific fields
+	tests := []struct {
+		field      string
+		wantType   string
+		wantSystem string
+	}{
+		{"summary", "string", "summary"},
+		{"assignee", "user", "assignee"},
+		{"status", "status", "status"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.field, func(t *testing.T) {
+			schema, ok := result.Schema[tc.field]
+			if !ok {
+				t.Errorf("Schema field %s not found", tc.field)
+				return
+			}
+			if schema.Type != tc.wantType {
+				t.Errorf("Schema field %s: got type %s, want %s", tc.field, schema.Type, tc.wantType)
+			}
+			if schema.System != tc.wantSystem {
+				t.Errorf("Schema field %s: got system %s, want %s", tc.field, schema.System, tc.wantSystem)
+			}
+		})
+	}
+}

--- a/pkg/infra/models/jira_search_v3.go
+++ b/pkg/infra/models/jira_search_v3.go
@@ -18,13 +18,13 @@ type IssueTransitionsScheme struct {
 
 // IssueSearchJQLScheme represents the response from the new JQL search endpoint for ADF (v3 API)
 type IssueSearchJQLScheme struct {
-	StartAt       int               `json:"startAt,omitempty"`
-	MaxResults    int               `json:"maxResults,omitempty"`
-	Total         int               `json:"total,omitempty"`
-	Issues        []*IssueScheme    `json:"issues,omitempty"`
-	Names         map[string]string `json:"names,omitempty"`
-	Schema        map[string]string `json:"schema,omitempty"`
-	NextPageToken string            `json:"nextPageToken,omitempty"`
+	StartAt       int                          `json:"startAt,omitempty"`
+	MaxResults    int                          `json:"maxResults,omitempty"`
+	Total         int                          `json:"total,omitempty"`
+	Issues        []*IssueScheme               `json:"issues,omitempty"`
+	Names         map[string]string            `json:"names,omitempty"`
+	Schema        map[string]*IssueFieldSchema `json:"schema,omitempty"`
+	NextPageToken string                       `json:"nextPageToken,omitempty"`
 }
 
 // IssueBulkFetchScheme represents the response from the bulk fetch endpoint for ADF (v3 API)


### PR DESCRIPTION
## Summary
- Fixes issue #404 where the schema field couldn't be unmarshaled when using `expand="schema"` in JQL searches
- Changes the schema field type from `map[string]string` to `map[string]*IssueFieldSchema`
- Affects both v2 and v3 API models

## Problem
When fetching issues through the new JQL search endpoint with `expand="schema"`, users received the error:
```
cannot unmarshal object into Go struct field IssueSearchJQLSchemeV2.schema of type string
```

The API returns schema as nested objects:
```json
"schema": {
    "summary": {
        "type": "string",
        "system": "summary"
    },
    "assignee": {
        "type": "user",
        "system": "assignee"
    }
}
```

But the struct incorrectly expected `map[string]string`.

## Changes
- Added `IssueFieldSchema` struct with `Type` and `System` fields
- Updated `IssueSearchJQLSchemeV2.Schema` to use `map[string]*IssueFieldSchema`
- Updated `IssueSearchJQLScheme.Schema` to use `map[string]*IssueFieldSchema`
- Added unit test to verify correct unmarshaling

## Test plan
- [x] Added unit test that verifies schema unmarshaling works correctly
- [x] Test passes with the new struct definition
- [ ] Manual testing with actual Jira API (requires credentials)

Fixes #404

🤖 Generated with [Claude Code](https://claude.ai/code)