### PR TITLE
fix(confluence): correct restriction API endpoint paths

### DIFF
--- a/confluence/internal/restriction_operation_content_impl.go
+++ b/confluence/internal/restriction_operation_content_impl.go
@@ -39,7 +39,7 @@ type RestrictionOperationService struct {
 //
 // of the return object, rather than items in a results array.
 //
-// GET /wiki/rest/api/content/{id}/restriction
+// GET /wiki/rest/api/content/{id}/restriction/byOperation
 //
 // https://docs.go-atlassian.io/confluence-cloud/content/restrictions/operations#get-restrictions-by-operation
 func (r *RestrictionOperationService) Gets(ctx context.Context, contentID string, expand []string) (*model.ContentRestrictionByOperationScheme, *model.ResponseScheme, error) {

--- a/confluence/internal/restriction_operation_group_content_impl.go
+++ b/confluence/internal/restriction_operation_group_content_impl.go
@@ -6,9 +6,7 @@ import (
 	model "github.com/ctreminiom/go-atlassian/v2/pkg/infra/models"
 	"github.com/ctreminiom/go-atlassian/v2/service"
 	"github.com/ctreminiom/go-atlassian/v2/service/confluence"
-	"github.com/google/uuid"
 	"net/http"
-	"strings"
 )
 
 // NewRestrictionOperationGroupService creates a new instance of RestrictionOperationGroupService.
@@ -78,20 +76,9 @@ func (i *internalRestrictionOperationGroupImpl) Get(ctx context.Context, content
 		return nil, fmt.Errorf("confluence: %w", model.ErrNoConfluenceGroup)
 	}
 
-	var endpoint strings.Builder
-	endpoint.WriteString(fmt.Sprintf("wiki/rest/api/content/%v/restriction/byOperation/%v/", contentID, operationKey))
+	endpoint := fmt.Sprintf("wiki/rest/api/content/%v/restriction/byOperation/%v/byGroupId/%v", contentID, operationKey, groupNameOrID)
 
-	// check if the group id is an uuid type
-	// if so, it's the group id
-	groupID, err := uuid.Parse(groupNameOrID)
-
-	if err == nil {
-		endpoint.WriteString(fmt.Sprintf("byGroupId/%v", groupID.String()))
-	} else {
-		endpoint.WriteString(fmt.Sprintf("group/%v", groupNameOrID))
-	}
-
-	request, err := i.c.NewRequest(ctx, http.MethodGet, endpoint.String(), "", nil)
+	request, err := i.c.NewRequest(ctx, http.MethodGet, endpoint, "", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -113,20 +100,9 @@ func (i *internalRestrictionOperationGroupImpl) Add(ctx context.Context, content
 		return nil, fmt.Errorf("confluence: %w", model.ErrNoConfluenceGroup)
 	}
 
-	var endpoint strings.Builder
-	endpoint.WriteString(fmt.Sprintf("wiki/rest/api/content/%v/restriction/byOperation/%v/", contentID, operationKey))
+	endpoint := fmt.Sprintf("wiki/rest/api/content/%v/restriction/byOperation/%v/byGroupId/%v", contentID, operationKey, groupNameOrID)
 
-	// check if the group id is an uuid type
-	// if so, it's the group id
-	groupID, err := uuid.Parse(groupNameOrID)
-
-	if err == nil {
-		endpoint.WriteString(fmt.Sprintf("byGroupId/%v", groupID.String()))
-	} else {
-		endpoint.WriteString(fmt.Sprintf("group/%v", groupNameOrID))
-	}
-
-	request, err := i.c.NewRequest(ctx, http.MethodPut, endpoint.String(), "", nil)
+	request, err := i.c.NewRequest(ctx, http.MethodPut, endpoint, "", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -148,20 +124,9 @@ func (i *internalRestrictionOperationGroupImpl) Remove(ctx context.Context, cont
 		return nil, fmt.Errorf("confluence: %w", model.ErrNoConfluenceGroup)
 	}
 
-	var endpoint strings.Builder
-	endpoint.WriteString(fmt.Sprintf("wiki/rest/api/content/%v/restriction/byOperation/%v/", contentID, operationKey))
+	endpoint := fmt.Sprintf("wiki/rest/api/content/%v/restriction/byOperation/%v/byGroupId/%v", contentID, operationKey, groupNameOrID)
 
-	// check if the group id is an uuid type
-	// if so, it's the group id
-	groupID, err := uuid.Parse(groupNameOrID)
-
-	if err == nil {
-		endpoint.WriteString(fmt.Sprintf("byGroupId/%v", groupID.String()))
-	} else {
-		endpoint.WriteString(fmt.Sprintf("group/%v", groupNameOrID))
-	}
-
-	request, err := i.c.NewRequest(ctx, http.MethodDelete, endpoint.String(), "", nil)
+	request, err := i.c.NewRequest(ctx, http.MethodDelete, endpoint, "", nil)
 	if err != nil {
 		return nil, err
 	}

--- a/confluence/internal/restriction_operation_group_content_impl_test.go
+++ b/confluence/internal/restriction_operation_group_content_impl_test.go
@@ -47,7 +47,7 @@ func Test_internalRestrictionOperationGroupImpl_Get(t *testing.T) {
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodGet,
-					"wiki/rest/api/content/100001/restriction/byOperation/read/group/confluence-users",
+					"wiki/rest/api/content/100001/restriction/byOperation/read/byGroupId/confluence-users",
 					"", nil).
 					Return(&http.Request{}, nil)
 
@@ -76,7 +76,7 @@ func Test_internalRestrictionOperationGroupImpl_Get(t *testing.T) {
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodGet,
-					"wiki/rest/api/content/100001/restriction/byOperation/read/group/confluence-users",
+					"wiki/rest/api/content/100001/restriction/byOperation/read/byGroupId/confluence-users",
 					"", nil).
 					Return(&http.Request{}, model.ErrCreateHttpReq)
 
@@ -188,7 +188,7 @@ func Test_internalRestrictionOperationGroupImpl_Add(t *testing.T) {
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodPut,
-					"wiki/rest/api/content/100001/restriction/byOperation/read/group/confluence-users",
+					"wiki/rest/api/content/100001/restriction/byOperation/read/byGroupId/confluence-users",
 					"", nil).
 					Return(&http.Request{}, nil)
 
@@ -217,7 +217,7 @@ func Test_internalRestrictionOperationGroupImpl_Add(t *testing.T) {
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodPut,
-					"wiki/rest/api/content/100001/restriction/byOperation/read/group/confluence-users",
+					"wiki/rest/api/content/100001/restriction/byOperation/read/byGroupId/confluence-users",
 					"", nil).
 					Return(&http.Request{}, model.ErrCreateHttpReq)
 
@@ -329,7 +329,7 @@ func Test_internalRestrictionOperationGroupImpl_Remove(t *testing.T) {
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodDelete,
-					"wiki/rest/api/content/100001/restriction/byOperation/read/group/confluence-users",
+					"wiki/rest/api/content/100001/restriction/byOperation/read/byGroupId/confluence-users",
 					"", nil).
 					Return(&http.Request{}, nil)
 
@@ -387,7 +387,7 @@ func Test_internalRestrictionOperationGroupImpl_Remove(t *testing.T) {
 				client.On("NewRequest",
 					context.Background(),
 					http.MethodDelete,
-					"wiki/rest/api/content/100001/restriction/byOperation/read/group/confluence-users",
+					"wiki/rest/api/content/100001/restriction/byOperation/read/byGroupId/confluence-users",
 					"", nil).
 					Return(&http.Request{}, model.ErrCreateHttpReq)
 


### PR DESCRIPTION
## Summary
- Fixed incorrect API endpoint paths in Confluence restriction operations
- Corrected documentation comments to match actual API paths
- Simplified group restriction endpoint implementation

## Changes
1. **Fixed comment typo in `restriction_operation_content_impl.go`**:
   - Comment incorrectly showed `/restriction` instead of `/restriction/byOperation`

2. **Corrected group restriction endpoint URLs**:
   - All group endpoints now consistently use `/byGroupId/{groupId}` pattern
   - Removed UUID detection logic that was incorrectly routing to different paths
   - API spec shows all group operations should use `/byGroupId/` regardless of identifier type

3. **Updated tests**:
   - Fixed test expectations to match corrected endpoint paths
   - All tests continue to pass

4. **Code cleanup**:
   - Removed unused imports (`uuid` and `strings` packages)
   - Simplified endpoint construction logic

## Test plan
- [x] Run existing tests: `go test -v ./confluence/internal/`
- [x] Verify linting passes: `golangci-lint run`
- [x] Code formatting: `go fmt ./...`

All tests pass successfully with the corrected endpoint paths.

🤖 Generated with [Claude Code](https://claude.ai/code)