### PR TITLE
feat: add support update issue comment

### DIFF
--- a/jira/internal/comment_impl_adf.go
+++ b/jira/internal/comment_impl_adf.go
@@ -55,6 +55,15 @@ func (c *CommentADFService) Add(ctx context.Context, issueKeyOrID string, payloa
 	return c.internalClient.Add(ctx, issueKeyOrID, payload, expand)
 }
 
+// Update updates a comment.
+//
+// PUT /rest/api/{2-3}/issue/{issueKeyOrID}/comment/{id}
+//
+// TODO: The documentation needs to be created, raise a ticket here: https://github.com/ctreminiom/go-atlassian/issues
+func (c *CommentADFService) Update(ctx context.Context, issueKeyOrID, commentID string, payload *model.CommentPayloadScheme, expand []string, notifyUsers, overrideEditableFlag bool) (*model.IssueCommentScheme, *model.ResponseScheme, error) {
+	return c.internalClient.Update(ctx, issueKeyOrID, commentID, payload, expand, notifyUsers, overrideEditableFlag)
+}
+
 type internalAdfCommentImpl struct {
 	c       service.Connector
 	version string
@@ -159,6 +168,45 @@ func (i *internalAdfCommentImpl) Add(ctx context.Context, issueKeyOrID string, p
 	}
 
 	request, err := i.c.NewRequest(ctx, http.MethodPost, endpoint.String(), "", payload)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	comment := new(model.IssueCommentScheme)
+	response, err := i.c.Call(request, comment)
+	if err != nil {
+		return nil, response, err
+	}
+
+	return comment, response, nil
+}
+
+func (i *internalAdfCommentImpl) Update(ctx context.Context, issueKeyOrID, commentID string, payload *model.CommentPayloadScheme, expand []string, notifyUsers, overrideEditableFlag bool) (*model.IssueCommentScheme, *model.ResponseScheme, error) {
+
+	if issueKeyOrID == "" {
+		return nil, nil, model.ErrNoIssueKeyOrID
+	}
+
+	if commentID == "" {
+		return nil, nil, model.ErrNoCommentID
+	}
+
+	params := url.Values{}
+	params.Add("notifyUsers", fmt.Sprintf("%v", notifyUsers))
+	params.Add("overrideEditableFlag", fmt.Sprintf("%v", overrideEditableFlag))
+
+	if len(expand) != 0 {
+		params.Add("expand", strings.Join(expand, ","))
+	}
+
+	var endpoint strings.Builder
+	endpoint.WriteString(fmt.Sprintf("rest/api/%v/issue/%v/comment/%v", i.version, issueKeyOrID, commentID))
+
+	if params.Encode() != "" {
+		endpoint.WriteString(fmt.Sprintf("?%v", params.Encode()))
+	}
+
+	request, err := i.c.NewRequest(ctx, http.MethodPut, endpoint.String(), "", payload)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/service/jira/comment.go
+++ b/service/jira/comment.go
@@ -29,6 +29,13 @@ type CommentRichTextConnector interface {
 	//
 	//https://docs.go-atlassian.io/jira-software-cloud/issues/comments#add-comment
 	Add(ctx context.Context, issueKeyOrID string, payload *model.CommentPayloadSchemeV2, expand []string) (*model.IssueCommentSchemeV2, *model.ResponseScheme, error)
+
+	// Update updates a comment.
+	//
+	// PUT /rest/api/{2-3}/issue/{issueIdOrKey}/comment/{id}
+	//
+	// TODO: The documentation needs to be created, raise a ticket here: https://github.com/ctreminiom/go-atlassian/issues
+	Update(ctx context.Context, issueKeyOrID, commentID string, payload *model.CommentPayloadSchemeV2, expand []string, notifyUsers, overrideEditableFlag bool) (*model.IssueCommentSchemeV2, *model.ResponseScheme, error)
 }
 
 type CommentADFConnector interface {
@@ -54,6 +61,13 @@ type CommentADFConnector interface {
 	//
 	// https://docs.go-atlassian.io/jira-software-cloud/issues/comments#add-comment
 	Add(ctx context.Context, issueKeyOrID string, payload *model.CommentPayloadScheme, expand []string) (*model.IssueCommentScheme, *model.ResponseScheme, error)
+
+	// Update updates a comment.
+	//
+	// PUT /rest/api/{2-3}/issue/{issueIdOrKey}/comment/{id}
+	//
+	// TODO: The documentation needs to be created, raise a ticket here: https://github.com/ctreminiom/go-atlassian/issues
+	Update(ctx context.Context, issueKeyOrID, commentID string, payload *model.CommentPayloadScheme, expand []string, notifyUsers, overrideEditableFlag bool) (*model.IssueCommentScheme, *model.ResponseScheme, error)
 }
 
 type CommentSharedConnector interface {


### PR DESCRIPTION
Description
---

This PR adds support for updating Jira issue comments using the Jira Cloud REST API.

Issue: #415 

Main changes:
---
Implemented a new method for updating an issue comment via the endpoint:
PUT /rest/api/{3 / 2}/issue/{issueIdOrKey}/comment/{id}

Reference
---
Jira REST API documentation:
* [Update comment V3](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-comments/#api-rest-api-3-issue-issueidorkey-comment-id-put)
* [Update comment V2](https://developer.atlassian.com/cloud/jira/platform/rest/v2/api-group-issue-comments/#api-rest-api-2-issue-issueidorkey-comment-id-put)