### PR TITLE
Fix lint issues and simplify CI workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,17 +16,12 @@ permissions:
 jobs:
   golangci:
     name: GolangCI-Lint
-    strategy:
-      max-parallel: 6
-      matrix:
-        go: [ 1.23, 1.24]
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
       - name: Setup Go
         uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v5
         with:
-          go-version: ${{ matrix.go }}
+          go-version: '1.24'
 
       - name: Checkout code
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4

--- a/examples/jira_oauth2_server_example.go
+++ b/examples/jira_oauth2_server_example.go
@@ -1,5 +1,4 @@
 //go:build ignore
-// +build ignore
 
 package main
 

--- a/examples/jira_oauth2_storage_file_example.go
+++ b/examples/jira_oauth2_storage_file_example.go
@@ -1,5 +1,4 @@
 //go:build ignore
-// +build ignore
 
 package main
 

--- a/examples/jira_oauth2_storage_redis_example.go
+++ b/examples/jira_oauth2_storage_redis_example.go
@@ -1,5 +1,4 @@
 //go:build ignore
-// +build ignore
 
 package main
 


### PR DESCRIPTION
## Summary
- Removed outdated `// +build ignore` directives from 3 example files
- Simplified lint workflow to use only Go 1.24 on ubuntu-latest
- Reduced CI matrix from 6 parallel jobs to 1 for faster execution

## Changes
### Lint Fixes
Fixed `buildtag` lint errors in:
- `examples/jira_oauth2_server_example.go`
- `examples/jira_oauth2_storage_file_example.go`
- `examples/jira_oauth2_storage_redis_example.go`

The old `// +build ignore` format is no longer needed since the modern `//go:build ignore` directive is already present.

### CI Optimization
Updated `.github/workflows/lint.yml`:
- Removed matrix strategy (previously tested on 3 OS × 2 Go versions = 6 jobs)
- Now runs on single environment: Go 1.24 on ubuntu-latest
- Faster CI execution while maintaining sufficient code quality validation

## Test plan
- [x] Verified locally with `golangci-lint run --timeout=10m`
- [x] All lint checks pass (0 issues)
- [x] Changes are platform-independent