### PR TITLE
🐛 Fix MergeCustomFields and MergeOperations returning empty map when input is nil

### DIFF
--- a/pkg/infra/models/jira_issue_v2.go
+++ b/pkg/infra/models/jira_issue_v2.go
@@ -19,12 +19,8 @@ type IssueSchemeV2 struct {
 
 // MergeCustomFields merges custom fields into the issue scheme.
 // It returns a map representation of the issue scheme with the merged fields.
-// If the provided fields are nil or empty, it returns an error.
+// If the provided fields are nil or empty, it returns the issue scheme as a map.
 func (i *IssueSchemeV2) MergeCustomFields(fields *CustomFields) (map[string]interface{}, error) {
-
-	if fields == nil || len(fields.Fields) == 0 {
-		return map[string]interface{}{}, nil
-	}
 
 	// Convert the IssueScheme struct to map[string]interface{}
 	issueSchemeAsBytes, err := json.Marshal(i)
@@ -35,6 +31,10 @@ func (i *IssueSchemeV2) MergeCustomFields(fields *CustomFields) (map[string]inte
 	issueSchemeAsMap := make(map[string]interface{})
 	if err := json.Unmarshal(issueSchemeAsBytes, &issueSchemeAsMap); err != nil {
 		return nil, err
+	}
+
+	if fields == nil || len(fields.Fields) == 0 {
+		return issueSchemeAsMap, nil
 	}
 
 	// For each customField created, merge it into the eAsMap
@@ -49,19 +49,15 @@ func (i *IssueSchemeV2) MergeCustomFields(fields *CustomFields) (map[string]inte
 
 // MergeOperations merges operations into the issue scheme.
 // It returns a map representation of the issue scheme with the merged operations.
-// If the provided operations are nil or empty, it returns an error.
+// If the provided operations are nil or empty, it returns the issue scheme as a map.
 //
 // Parameters:
 // - operations: A pointer to UpdateOperations containing the operations to be merged.
 //
 // Returns:
 // - A map[string]interface{} representing the issue scheme with the merged operations.
-// - An error if the operations are nil, empty, or if there is an issue during the merging process.
+// - An error if there is an issue during the merging process.
 func (i *IssueSchemeV2) MergeOperations(operations *UpdateOperations) (map[string]interface{}, error) {
-
-	if operations == nil || len(operations.Fields) == 0 {
-		return map[string]interface{}{}, nil
-	}
 
 	// Convert the IssueScheme struct to map[string]interface{}
 	issueSchemeAsBytes, err := json.Marshal(i)
@@ -72,6 +68,10 @@ func (i *IssueSchemeV2) MergeOperations(operations *UpdateOperations) (map[strin
 	issueSchemeAsMap := make(map[string]interface{})
 	if err := json.Unmarshal(issueSchemeAsBytes, &issueSchemeAsMap); err != nil {
 		return nil, err
+	}
+
+	if operations == nil || len(operations.Fields) == 0 {
+		return issueSchemeAsMap, nil
 	}
 
 	// For each customField created, merge it into the eAsMap

--- a/pkg/infra/models/jira_issue_v2_test.go
+++ b/pkg/infra/models/jira_issue_v2_test.go
@@ -48,6 +48,28 @@ func TestIssueSchemeV2_MergeCustomFields(t *testing.T) {
 			wantErr: false,
 			Err:     nil,
 		},
+		{
+			name: "when custom fields is nil, should preserve issue scheme fields",
+			fields: fields{
+				ID:  "10001",
+				Key: "TEST-1",
+				Fields: &IssueFieldsSchemeV2{
+					Summary: "Test Summary",
+				},
+			},
+			args: args{
+				fields: nil,
+			},
+			want: map[string]interface{}{
+				"id":  "10001",
+				"key": "TEST-1",
+				"fields": map[string]interface{}{
+					"summary": "Test Summary",
+				},
+			},
+			wantErr: false,
+			Err:     nil,
+		},
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
@@ -116,6 +138,28 @@ func TestIssueSchemeV2_MergeOperations(t *testing.T) {
 							"remove": "triaged",
 						},
 					},
+				},
+			},
+			wantErr: false,
+			Err:     nil,
+		},
+		{
+			name: "when operations is nil, should preserve issue scheme fields",
+			fields: fields{
+				ID:  "10001",
+				Key: "TEST-1",
+				Fields: &IssueFieldsSchemeV2{
+					Summary: "Test Summary",
+				},
+			},
+			args: args{
+				operations: nil,
+			},
+			want: map[string]interface{}{
+				"id":  "10001",
+				"key": "TEST-1",
+				"fields": map[string]interface{}{
+					"summary": "Test Summary",
 				},
 			},
 			wantErr: false,

--- a/pkg/infra/models/jira_issue_v3.go
+++ b/pkg/infra/models/jira_issue_v3.go
@@ -19,14 +19,10 @@ type IssueScheme struct {
 
 // MergeCustomFields merges custom fields into the issue scheme.
 // It returns a map representation of the issue scheme with the merged fields.
-// If the provided fields are nil or empty, it returns an error.
+// If the provided fields are nil or empty, it returns the issue scheme as a map.
 func (i *IssueScheme) MergeCustomFields(fields *CustomFields) (map[string]interface{}, error) {
 
-	if fields == nil || len(fields.Fields) == 0 {
-		return map[string]interface{}{}, nil
-	}
-
-	//Convert the IssueScheme struct to map[string]interface{}
+	// Convert the IssueScheme struct to map[string]interface{}
 	issueSchemeAsBytes, err := json.Marshal(i)
 	if err != nil {
 		return nil, err
@@ -37,7 +33,11 @@ func (i *IssueScheme) MergeCustomFields(fields *CustomFields) (map[string]interf
 		return nil, err
 	}
 
-	//For each customField created, merge it into the eAsMap
+	if fields == nil || len(fields.Fields) == 0 {
+		return issueSchemeAsMap, nil
+	}
+
+	// For each customField created, merge it into the eAsMap
 	for _, customField := range fields.Fields {
 		if err := mergo.Merge(&issueSchemeAsMap, customField, mergo.WithOverride); err != nil {
 			return nil, err
@@ -49,21 +49,17 @@ func (i *IssueScheme) MergeCustomFields(fields *CustomFields) (map[string]interf
 
 // MergeOperations merges operations into the issue scheme.
 // It returns a map representation of the issue scheme with the merged operations.
-// If the provided operations are nil or empty, it returns an error.
+// If the provided operations are nil or empty, it returns the issue scheme as a map.
 //
 // Parameters:
 // - operations: A pointer to UpdateOperations containing the operations to be merged.
 //
 // Returns:
 // - A map[string]interface{} representing the issue scheme with the merged operations.
-// - An error if the operations are nil, empty, or if there is an issue during the merging process.
+// - An error if there is an issue during the merging process.
 func (i *IssueScheme) MergeOperations(operations *UpdateOperations) (map[string]interface{}, error) {
 
-	if operations == nil || len(operations.Fields) == 0 {
-		return map[string]interface{}{}, nil
-	}
-
-	//Convert the IssueScheme struct to map[string]interface{}
+	// Convert the IssueScheme struct to map[string]interface{}
 	issueSchemeAsBytes, err := json.Marshal(i)
 	if err != nil {
 		return nil, err
@@ -74,7 +70,11 @@ func (i *IssueScheme) MergeOperations(operations *UpdateOperations) (map[string]
 		return nil, err
 	}
 
-	//For each customField created, merge it into the eAsMap
+	if operations == nil || len(operations.Fields) == 0 {
+		return issueSchemeAsMap, nil
+	}
+
+	// For each customField created, merge it into the eAsMap
 	for _, customField := range operations.Fields {
 		if err := mergo.Merge(&issueSchemeAsMap, customField, mergo.WithOverride); err != nil {
 			return nil, err

--- a/pkg/infra/models/jira_issue_v3_test.go
+++ b/pkg/infra/models/jira_issue_v3_test.go
@@ -47,6 +47,28 @@ func TestIssueScheme_MergeCustomFields(t *testing.T) {
 			wantErr: false,
 			Err:     nil,
 		},
+		{
+			name: "when custom fields is nil, should preserve issue scheme fields",
+			fields: fields{
+				ID:  "10001",
+				Key: "TEST-1",
+				Fields: &IssueFieldsScheme{
+					Summary: "Test Summary",
+				},
+			},
+			args: args{
+				fields: nil,
+			},
+			want: map[string]interface{}{
+				"id":  "10001",
+				"key": "TEST-1",
+				"fields": map[string]interface{}{
+					"summary": "Test Summary",
+				},
+			},
+			wantErr: false,
+			Err:     nil,
+		},
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
@@ -115,6 +137,28 @@ func TestIssueScheme_MergeOperations(t *testing.T) {
 							"remove": "triaged",
 						},
 					},
+				},
+			},
+			wantErr: false,
+			Err:     nil,
+		},
+		{
+			name: "when operations is nil, should preserve issue scheme fields",
+			fields: fields{
+				ID:  "10001",
+				Key: "TEST-1",
+				Fields: &IssueFieldsScheme{
+					Summary: "Test Summary",
+				},
+			},
+			args: args{
+				operations: nil,
+			},
+			want: map[string]interface{}{
+				"id":  "10001",
+				"key": "TEST-1",
+				"fields": map[string]interface{}{
+					"summary": "Test Summary",
 				},
 			},
 			wantErr: false,


### PR DESCRIPTION
## Summary
- Fix `MergeCustomFields` and `MergeOperations` methods in both v2 and v3 issue schemes to return the issue scheme as a map when input is nil/empty, instead of returning an empty map
- This preserves standard fields (like `Resolution`) when calling `Issue.Move()` with nil `CustomFields` and `Operations`
- Added test cases for the nil input scenario

Fixes #436

## Test plan
- [x] Existing unit tests pass
- [x] New test cases added for nil input scenario (`when custom fields is nil, should preserve issue scheme fields` and `when operations is nil, should preserve issue scheme fields`)
- [x] Jira internal tests pass (`go test ./jira/internal/...`)
- [ ] Manual test with the reproduction case from issue #436