### PR TITLE
✨ Add Update method for Jira issue comments

### DIFF
--- a/jira/internal/comment_impl_adf.go
+++ b/jira/internal/comment_impl_adf.go
@@ -55,6 +55,15 @@ func (c *CommentADFService) Add(ctx context.Context, issueKeyOrID string, payloa
 	return c.internalClient.Add(ctx, issueKeyOrID, payload, expand)
 }
 
+// Update updates a comment.
+//
+// PUT /rest/api/{2-3}/issue/{issueKeyOrID}/comment/{commentID}
+//
+// https://docs.go-atlassian.io/jira-software-cloud/issues/comments#update-comment
+func (c *CommentADFService) Update(ctx context.Context, issueKeyOrID, commentID string, payload *model.CommentPayloadScheme, expand []string) (*model.IssueCommentScheme, *model.ResponseScheme, error) {
+	return c.internalClient.Update(ctx, issueKeyOrID, commentID, payload, expand)
+}
+
 type internalAdfCommentImpl struct {
 	c       service.Connector
 	version string
@@ -159,6 +168,42 @@ func (i *internalAdfCommentImpl) Add(ctx context.Context, issueKeyOrID string, p
 	}
 
 	request, err := i.c.NewRequest(ctx, http.MethodPost, endpoint.String(), "", payload)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	comment := new(model.IssueCommentScheme)
+	response, err := i.c.Call(request, comment)
+	if err != nil {
+		return nil, response, err
+	}
+
+	return comment, response, nil
+}
+
+func (i *internalAdfCommentImpl) Update(ctx context.Context, issueKeyOrID, commentID string, payload *model.CommentPayloadScheme, expand []string) (*model.IssueCommentScheme, *model.ResponseScheme, error) {
+
+	if issueKeyOrID == "" {
+		return nil, nil, fmt.Errorf("jira: %w", model.ErrNoIssueKeyOrID)
+	}
+
+	if commentID == "" {
+		return nil, nil, fmt.Errorf("jira: %w", model.ErrNoCommentID)
+	}
+
+	params := url.Values{}
+	if len(expand) != 0 {
+		params.Add("expand", strings.Join(expand, ","))
+	}
+
+	var endpoint strings.Builder
+	endpoint.WriteString(fmt.Sprintf("rest/api/%v/issue/%v/comment/%v", i.version, issueKeyOrID, commentID))
+
+	if params.Encode() != "" {
+		endpoint.WriteString(fmt.Sprintf("?%v", params.Encode()))
+	}
+
+	request, err := i.c.NewRequest(ctx, http.MethodPut, endpoint.String(), "", payload)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/jira/internal/comment_impl_adf_test.go
+++ b/jira/internal/comment_impl_adf_test.go
@@ -608,3 +608,178 @@ func Test_internalAdfCommentImpl_Add(t *testing.T) {
 		})
 	}
 }
+
+func Test_internalAdfCommentImpl_Update(t *testing.T) {
+
+	commentBody := model.CommentNodeScheme{}
+	commentBody.Version = 1
+	commentBody.Type = "doc"
+
+	commentBody.AppendNode(&model.CommentNodeScheme{
+		Type: "paragraph",
+		Content: []*model.CommentNodeScheme{
+			{
+				Type: "text",
+				Text: "Updated comment",
+			},
+		},
+	})
+
+	payloadMocked := &model.CommentPayloadScheme{
+		Visibility: &model.CommentVisibilityScheme{
+			Type:  "role",
+			Value: "Administrators",
+		},
+		Body: &commentBody,
+	}
+
+	type fields struct {
+		c       service.Connector
+		version string
+	}
+
+	type args struct {
+		ctx          context.Context
+		issueKeyOrID string
+		commentID    string
+		payload      *model.CommentPayloadScheme
+		expand       []string
+	}
+
+	testCases := []struct {
+		name    string
+		fields  fields
+		args    args
+		on      func(*fields)
+		wantErr bool
+		Err     error
+	}{
+		{
+			name:   "when the document format is adf (atlassian document format)",
+			fields: fields{version: "3"},
+			args: args{
+				ctx:          context.Background(),
+				issueKeyOrID: "DUMMY-1",
+				commentID:    "10001",
+				payload:      payloadMocked,
+				expand:       []string{"body"},
+			},
+			on: func(fields *fields) {
+
+				client := mocks.NewConnector(t)
+
+				client.On("NewRequest",
+					context.Background(),
+					http.MethodPut,
+					"rest/api/3/issue/DUMMY-1/comment/10001?expand=body",
+					"",
+					payloadMocked).
+					Return(&http.Request{}, nil)
+
+				client.On("Call",
+					&http.Request{},
+					&model.IssueCommentScheme{}).
+					Return(&model.ResponseScheme{}, nil)
+
+				fields.c = client
+
+			},
+			wantErr: false,
+			Err:     nil,
+		},
+
+		{
+			name:   "when the issue key or id is not provided",
+			fields: fields{version: "3"},
+			args: args{
+				ctx:          context.Background(),
+				issueKeyOrID: "",
+				commentID:    "10001",
+				payload:      payloadMocked,
+				expand:       []string{"body"},
+			},
+			wantErr: true,
+			Err:     model.ErrNoIssueKeyOrID,
+		},
+
+		{
+			name:   "when the comment id is not provided",
+			fields: fields{version: "3"},
+			args: args{
+				ctx:          context.Background(),
+				issueKeyOrID: "DUMMY-1",
+				commentID:    "",
+				payload:      payloadMocked,
+				expand:       []string{"body"},
+			},
+			wantErr: true,
+			Err:     model.ErrNoCommentID,
+		},
+
+		{
+			name:   "when the http request cannot be created",
+			fields: fields{version: "3"},
+			args: args{
+				ctx:          context.Background(),
+				issueKeyOrID: "DUMMY-1",
+				commentID:    "10001",
+				payload:      payloadMocked,
+				expand:       []string{"body"},
+			},
+			on: func(fields *fields) {
+
+				client := mocks.NewConnector(t)
+
+				client.On("NewRequest",
+					context.Background(),
+					http.MethodPut,
+					"rest/api/3/issue/DUMMY-1/comment/10001?expand=body",
+					"",
+					payloadMocked).
+					Return(&http.Request{}, model.ErrCreateHttpReq)
+
+				fields.c = client
+
+			},
+			wantErr: true,
+			Err:     model.ErrCreateHttpReq,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+
+			if testCase.on != nil {
+				testCase.on(&testCase.fields)
+			}
+
+			commentService, _, err := NewCommentService(testCase.fields.c, testCase.fields.version)
+			assert.NoError(t, err)
+
+			gotResult, gotResponse, err := commentService.Update(testCase.args.ctx, testCase.args.issueKeyOrID,
+				testCase.args.commentID, testCase.args.payload, testCase.args.expand)
+
+			if testCase.wantErr {
+
+				if err != nil {
+					t.Logf("error returned: %v", err.Error())
+				}
+
+				// the first if statement is to handle wrapped errors from url and json packages for more accurate comparison
+				var urlErr *url.Error
+				var jsonErr *json.SyntaxError
+				if errors.As(err, &urlErr) || errors.As(err, &jsonErr) {
+					assert.Contains(t, err.Error(), testCase.Err.Error())
+				} else {
+					assert.True(t, errors.Is(err, testCase.Err), "expected error: %v, got: %v", testCase.Err, err)
+				}
+			} else {
+
+				assert.NoError(t, err)
+				assert.NotEqual(t, gotResponse, nil)
+				assert.NotEqual(t, gotResult, nil)
+			}
+
+		})
+	}
+}

--- a/jira/internal/comment_impl_rich_text.go
+++ b/jira/internal/comment_impl_rich_text.go
@@ -55,6 +55,15 @@ func (c *CommentRichTextService) Add(ctx context.Context, issueKeyOrID string, p
 	return c.internalClient.Add(ctx, issueKeyOrID, payload, expand)
 }
 
+// Update updates a comment.
+//
+// PUT /rest/api/{2-3}/issue/{issueKeyOrID}/comment/{commentID}
+//
+// https://docs.go-atlassian.io/jira-software-cloud/issues/comments#update-comment
+func (c *CommentRichTextService) Update(ctx context.Context, issueKeyOrID, commentID string, payload *model.CommentPayloadSchemeV2, expand []string) (*model.IssueCommentSchemeV2, *model.ResponseScheme, error) {
+	return c.internalClient.Update(ctx, issueKeyOrID, commentID, payload, expand)
+}
+
 type internalRichTextCommentImpl struct {
 	c       service.Connector
 	version string
@@ -159,6 +168,42 @@ func (i *internalRichTextCommentImpl) Add(ctx context.Context, issueKeyOrID stri
 	}
 
 	request, err := i.c.NewRequest(ctx, http.MethodPost, endpoint.String(), "", payload)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	comment := new(model.IssueCommentSchemeV2)
+	response, err := i.c.Call(request, comment)
+	if err != nil {
+		return nil, response, err
+	}
+
+	return comment, response, nil
+}
+
+func (i *internalRichTextCommentImpl) Update(ctx context.Context, issueKeyOrID, commentID string, payload *model.CommentPayloadSchemeV2, expand []string) (*model.IssueCommentSchemeV2, *model.ResponseScheme, error) {
+
+	if issueKeyOrID == "" {
+		return nil, nil, fmt.Errorf("jira: %w", model.ErrNoIssueKeyOrID)
+	}
+
+	if commentID == "" {
+		return nil, nil, fmt.Errorf("jira: %w", model.ErrNoCommentID)
+	}
+
+	params := url.Values{}
+	if len(expand) != 0 {
+		params.Add("expand", strings.Join(expand, ","))
+	}
+
+	var endpoint strings.Builder
+	endpoint.WriteString(fmt.Sprintf("rest/api/%v/issue/%v/comment/%v", i.version, issueKeyOrID, commentID))
+
+	if params.Encode() != "" {
+		endpoint.WriteString(fmt.Sprintf("?%v", params.Encode()))
+	}
+
+	request, err := i.c.NewRequest(ctx, http.MethodPut, endpoint.String(), "", payload)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/jira/internal/comment_impl_rich_text_test.go
+++ b/jira/internal/comment_impl_rich_text_test.go
@@ -577,3 +577,164 @@ func Test_internalRichTextCommentImpl_Add(t *testing.T) {
 		})
 	}
 }
+
+func Test_internalRichTextCommentImpl_Update(t *testing.T) {
+
+	payloadMocked := &model.CommentPayloadSchemeV2{
+		Visibility: &model.CommentVisibilityScheme{
+			Type:  "role",
+			Value: "Administrators",
+		},
+		Body: "updated comment",
+	}
+
+	type fields struct {
+		c       service.Connector
+		version string
+	}
+
+	type args struct {
+		ctx          context.Context
+		issueKeyOrID string
+		commentID    string
+		payload      *model.CommentPayloadSchemeV2
+		expand       []string
+	}
+
+	testCases := []struct {
+		name    string
+		fields  fields
+		args    args
+		on      func(*fields)
+		wantErr bool
+		Err     error
+	}{
+		{
+			name:   "when the document format is rich-text",
+			fields: fields{version: "2"},
+			args: args{
+				ctx:          context.Background(),
+				issueKeyOrID: "DUMMY-1",
+				commentID:    "10001",
+				payload:      payloadMocked,
+				expand:       []string{"body"},
+			},
+			on: func(fields *fields) {
+
+				client := mocks.NewConnector(t)
+
+				client.On("NewRequest",
+					context.Background(),
+					http.MethodPut,
+					"rest/api/2/issue/DUMMY-1/comment/10001?expand=body",
+					"",
+					payloadMocked).
+					Return(&http.Request{}, nil)
+
+				client.On("Call",
+					&http.Request{},
+					&model.IssueCommentSchemeV2{}).
+					Return(&model.ResponseScheme{}, nil)
+
+				fields.c = client
+
+			},
+			wantErr: false,
+			Err:     nil,
+		},
+
+		{
+			name:   "when the issue key or id is not provided",
+			fields: fields{version: "2"},
+			args: args{
+				ctx:          context.Background(),
+				issueKeyOrID: "",
+				commentID:    "10001",
+				payload:      payloadMocked,
+				expand:       []string{"body"},
+			},
+			wantErr: true,
+			Err:     model.ErrNoIssueKeyOrID,
+		},
+
+		{
+			name:   "when the comment id is not provided",
+			fields: fields{version: "2"},
+			args: args{
+				ctx:          context.Background(),
+				issueKeyOrID: "DUMMY-1",
+				commentID:    "",
+				payload:      payloadMocked,
+				expand:       []string{"body"},
+			},
+			wantErr: true,
+			Err:     model.ErrNoCommentID,
+		},
+
+		{
+			name:   "when the http request cannot be created",
+			fields: fields{version: "2"},
+			args: args{
+				ctx:          context.Background(),
+				issueKeyOrID: "DUMMY-1",
+				commentID:    "10001",
+				payload:      payloadMocked,
+				expand:       []string{"body"},
+			},
+			on: func(fields *fields) {
+
+				client := mocks.NewConnector(t)
+
+				client.On("NewRequest",
+					context.Background(),
+					http.MethodPut,
+					"rest/api/2/issue/DUMMY-1/comment/10001?expand=body",
+					"",
+					payloadMocked).
+					Return(&http.Request{}, model.ErrCreateHttpReq)
+
+				fields.c = client
+
+			},
+			wantErr: true,
+			Err:     model.ErrCreateHttpReq,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+
+			if testCase.on != nil {
+				testCase.on(&testCase.fields)
+			}
+
+			_, commentService, err := NewCommentService(testCase.fields.c, testCase.fields.version)
+			assert.NoError(t, err)
+
+			gotResult, gotResponse, err := commentService.Update(testCase.args.ctx, testCase.args.issueKeyOrID,
+				testCase.args.commentID, testCase.args.payload, testCase.args.expand)
+
+			if testCase.wantErr {
+
+				if err != nil {
+					t.Logf("error returned: %v", err.Error())
+				}
+
+				// the first if statement is to handle wrapped errors from url and json packages for more accurate comparison
+				var urlErr *url.Error
+				var jsonErr *json.SyntaxError
+				if errors.As(err, &urlErr) || errors.As(err, &jsonErr) {
+					assert.Contains(t, err.Error(), testCase.Err.Error())
+				} else {
+					assert.True(t, errors.Is(err, testCase.Err), "expected error: %v, got: %v", testCase.Err, err)
+				}
+			} else {
+
+				assert.NoError(t, err)
+				assert.NotEqual(t, gotResponse, nil)
+				assert.NotEqual(t, gotResult, nil)
+			}
+
+		})
+	}
+}

--- a/service/jira/comment.go
+++ b/service/jira/comment.go
@@ -29,6 +29,13 @@ type CommentRichTextConnector interface {
 	//
 	//https://docs.go-atlassian.io/jira-software-cloud/issues/comments#add-comment
 	Add(ctx context.Context, issueKeyOrID string, payload *model.CommentPayloadSchemeV2, expand []string) (*model.IssueCommentSchemeV2, *model.ResponseScheme, error)
+
+	// Update updates a comment.
+	//
+	// PUT /rest/api/{2-3}/issue/{issueKeyOrID}/comment/{commentID}
+	//
+	// https://docs.go-atlassian.io/jira-software-cloud/issues/comments#update-comment
+	Update(ctx context.Context, issueKeyOrID, commentID string, payload *model.CommentPayloadSchemeV2, expand []string) (*model.IssueCommentSchemeV2, *model.ResponseScheme, error)
 }
 
 type CommentADFConnector interface {
@@ -54,6 +61,13 @@ type CommentADFConnector interface {
 	//
 	// https://docs.go-atlassian.io/jira-software-cloud/issues/comments#add-comment
 	Add(ctx context.Context, issueKeyOrID string, payload *model.CommentPayloadScheme, expand []string) (*model.IssueCommentScheme, *model.ResponseScheme, error)
+
+	// Update updates a comment.
+	//
+	// PUT /rest/api/{2-3}/issue/{issueKeyOrID}/comment/{commentID}
+	//
+	// https://docs.go-atlassian.io/jira-software-cloud/issues/comments#update-comment
+	Update(ctx context.Context, issueKeyOrID, commentID string, payload *model.CommentPayloadScheme, expand []string) (*model.IssueCommentScheme, *model.ResponseScheme, error)
 }
 
 type CommentSharedConnector interface {


### PR DESCRIPTION
## Summary

- Add support for updating existing Jira issue comments via the REST API
- Implements both V2 (Rich Text) and V3 (ADF) API versions
- Uses endpoint: `PUT /rest/api/{2-3}/issue/{issueKeyOrID}/comment/{commentID}`

## Changes

- Add `Update` method to `CommentRichTextConnector` interface (V2 API)
- Add `Update` method to `CommentADFConnector` interface (V3 API)
- Add implementations in `comment_impl_rich_text.go` and `comment_impl_adf.go`
- Add unit tests for both implementations

## API Reference

- [Update comment API V3](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-comments/#api-rest-api-3-issue-issueidorkey-comment-id-put)
- [Update comment API V2](https://developer.atlassian.com/cloud/jira/platform/rest/v2/api-group-issue-comments/#api-rest-api-2-issue-issueidorkey-comment-id-put)

## Test plan

- [x] All existing tests pass
- [x] New tests added for Update method (ADF and RichText)
- [x] Tests cover: success case, missing issue key, missing comment ID, HTTP request error

Closes #415