### PR TITLE
🐛 Fix Confluence Folder API timestamp unmarshal failure

### DIFF
--- a/pkg/infra/models/confluence_folder.go
+++ b/pkg/infra/models/confluence_folder.go
@@ -11,7 +11,7 @@ type FolderScheme struct {
 	Position   int                  `json:"position,omitempty"`   // The position of the folder.
 	AuthorID   string               `json:"authorId,omitempty"`   // The ID of the author of the folder.
 	OwnerID    string               `json:"ownerId,omitempty"`    // The ID of the owner of the folder.
-	CreatedAt  string               `json:"createdAt,omitempty"`  // The timestamp of the creation of the folder.
+	CreatedAt  *ConfluenceDateTimeScheme `json:"createdAt,omitempty"`  // The timestamp of the creation of the folder.
 	SpaceID    string               `json:"spaceId,omitempty"`    // The ID of the space of the folder.
 	Version    *FolderVersionScheme `json:"version,omitempty"`    // The version information of the folder.
 	Links      *FolderLinksScheme   `json:"_links,omitempty"`     // The links of the folder.
@@ -19,7 +19,7 @@ type FolderScheme struct {
 
 // FolderVersionScheme represents the version information of a folder.
 type FolderVersionScheme struct {
-	CreatedAt string `json:"createdAt,omitempty"` // The timestamp of the creation of the version.
+	CreatedAt *ConfluenceDateTimeScheme `json:"createdAt,omitempty"` // The timestamp of the creation of the version.
 	Message   string `json:"message,omitempty"`   // The message of the version.
 	Number    int    `json:"number,omitempty"`    // The version number.
 	MinorEdit bool   `json:"minorEdit,omitempty"` // Indicates if the version is a minor edit.

--- a/pkg/infra/models/confluence_folder.go
+++ b/pkg/infra/models/confluence_folder.go
@@ -1,7 +1,5 @@
 package models
 
-import "time"
-
 // FolderScheme represents a folder in Confluence.
 type FolderScheme struct {
 	ID         string               `json:"id,omitempty"`         // The ID of the folder.
@@ -13,15 +11,19 @@ type FolderScheme struct {
 	Position   int                  `json:"position,omitempty"`   // The position of the folder.
 	AuthorID   string               `json:"authorId,omitempty"`   // The ID of the author of the folder.
 	OwnerID    string               `json:"ownerId,omitempty"`    // The ID of the owner of the folder.
-	CreatedAt  *time.Time           `json:"createdAt,omitempty"`  // The creation time of the folder.
+	CreatedAt  string               `json:"createdAt,omitempty"`  // The timestamp of the creation of the folder.
+	SpaceID    string               `json:"spaceId,omitempty"`    // The ID of the space of the folder.
 	Version    *FolderVersionScheme `json:"version,omitempty"`    // The version information of the folder.
 	Links      *FolderLinksScheme   `json:"_links,omitempty"`     // The links of the folder.
 }
 
 // FolderVersionScheme represents the version information of a folder.
 type FolderVersionScheme struct {
-	Number    int        `json:"number,omitempty"`    // The version number.
-	CreatedAt *time.Time `json:"createdAt,omitempty"` // The creation time of the version.
+	CreatedAt string `json:"createdAt,omitempty"` // The timestamp of the creation of the version.
+	Message   string `json:"message,omitempty"`   // The message of the version.
+	Number    int    `json:"number,omitempty"`    // The version number.
+	MinorEdit bool   `json:"minorEdit,omitempty"` // Indicates if the version is a minor edit.
+	AuthorID  string `json:"authorId,omitempty"`  // The ID of the author of the version.
 }
 
 // FolderLinksScheme represents the links of a folder.

--- a/pkg/infra/models/confluence_folder_test.go
+++ b/pkg/infra/models/confluence_folder_test.go
@@ -3,19 +3,23 @@ package models
 import (
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestFolderScheme_UnmarshalJSON(t *testing.T) {
+
+	ts := time.Date(2024, 9, 23, 20, 17, 35, 607000000, time.UTC)
+
 	tests := []struct {
-		name     string
-		json     string
-		expected FolderScheme
+		name string
+		json string
+		check func(t *testing.T, got FolderScheme)
 	}{
 		{
-			name: "full response from API",
+			name: "full response with string timestamps",
 			json: `{
 				"id": "123456",
 				"type": "folder",
@@ -39,41 +43,58 @@ func TestFolderScheme_UnmarshalJSON(t *testing.T) {
 					"self": "https://example.atlassian.net/wiki/api/v2/folders/123456"
 				}
 			}`,
-			expected: FolderScheme{
-				ID:         "123456",
-				Type:       "folder",
-				Status:     "current",
-				Title:      "My Folder",
-				ParentID:   "789",
-				ParentType: "page",
-				Position:   5,
-				AuthorID:   "author-1",
-				OwnerID:    "owner-1",
-				CreatedAt:  "2024-09-23T20:17:35.607Z",
-				SpaceID:    "space-42",
-				Version: &FolderVersionScheme{
-					CreatedAt: "2024-09-23T20:17:35.607Z",
-					Message:   "initial version",
-					Number:    1,
-					MinorEdit: false,
-					AuthorID:  "author-1",
-				},
-				Links: &FolderLinksScheme{
-					Self: "https://example.atlassian.net/wiki/api/v2/folders/123456",
-				},
+			check: func(t *testing.T, got FolderScheme) {
+				assert.Equal(t, "123456", got.ID)
+				assert.Equal(t, "folder", got.Type)
+				assert.Equal(t, "current", got.Status)
+				assert.Equal(t, "My Folder", got.Title)
+				assert.Equal(t, "789", got.ParentID)
+				assert.Equal(t, "page", got.ParentType)
+				assert.Equal(t, 5, got.Position)
+				assert.Equal(t, "author-1", got.AuthorID)
+				assert.Equal(t, "owner-1", got.OwnerID)
+				assert.Equal(t, "space-42", got.SpaceID)
+				assert.True(t, ts.Equal(time.Time(*got.CreatedAt)))
+
+				require.NotNil(t, got.Version)
+				assert.True(t, ts.Equal(time.Time(*got.Version.CreatedAt)))
+				assert.Equal(t, "initial version", got.Version.Message)
+				assert.Equal(t, 1, got.Version.Number)
+				assert.False(t, got.Version.MinorEdit)
+				assert.Equal(t, "author-1", got.Version.AuthorID)
+
+				require.NotNil(t, got.Links)
+				assert.Equal(t, "https://example.atlassian.net/wiki/api/v2/folders/123456", got.Links.Self)
+			},
+		},
+		{
+			name: "numeric epoch millisecond timestamps",
+			json: `{
+				"id": "123456",
+				"title": "Epoch Folder",
+				"createdAt": 1727122655607,
+				"version": {
+					"number": 1,
+					"createdAt": 1727122655607
+				}
+			}`,
+			check: func(t *testing.T, got FolderScheme) {
+				assert.Equal(t, "123456", got.ID)
+				assert.Equal(t, "Epoch Folder", got.Title)
+				assert.True(t, ts.Equal(time.Time(*got.CreatedAt)))
+				assert.True(t, ts.Equal(time.Time(*got.Version.CreatedAt)))
 			},
 		},
 		{
 			name: "minimal response",
 			json: `{
 				"id": "123456",
-				"title": "Minimal Folder",
-				"createdAt": "2025-01-15T10:30:00.000Z"
+				"title": "Minimal Folder"
 			}`,
-			expected: FolderScheme{
-				ID:        "123456",
-				Title:     "Minimal Folder",
-				CreatedAt: "2025-01-15T10:30:00.000Z",
+			check: func(t *testing.T, got FolderScheme) {
+				assert.Equal(t, "123456", got.ID)
+				assert.Equal(t, "Minimal Folder", got.Title)
+				assert.Nil(t, got.CreatedAt)
 			},
 		},
 	}
@@ -83,7 +104,7 @@ func TestFolderScheme_UnmarshalJSON(t *testing.T) {
 			var got FolderScheme
 			err := json.Unmarshal([]byte(tt.json), &got)
 			require.NoError(t, err)
-			assert.Equal(t, tt.expected, got)
+			tt.check(t, got)
 		})
 	}
 }
@@ -103,7 +124,7 @@ func TestFolderChunkScheme_UnmarshalJSON(t *testing.T) {
 			{
 				"id": "2",
 				"title": "Folder B",
-				"createdAt": "2024-07-20T14:30:00.000Z"
+				"createdAt": 1721486400000
 			}
 		],
 		"_links": {
@@ -118,9 +139,11 @@ func TestFolderChunkScheme_UnmarshalJSON(t *testing.T) {
 	assert.Len(t, got.Results, 2)
 	assert.Equal(t, "1", got.Results[0].ID)
 	assert.Equal(t, "Folder A", got.Results[0].Title)
-	assert.Equal(t, "2024-06-15T08:00:00.000Z", got.Results[0].CreatedAt)
-	assert.Equal(t, 1, got.Results[0].Version.Number)
-	assert.Equal(t, "2024-06-15T08:00:00.000Z", got.Results[0].Version.CreatedAt)
+
+	expectedTime := time.Date(2024, 6, 15, 8, 0, 0, 0, time.UTC)
+	assert.True(t, expectedTime.Equal(time.Time(*got.Results[0].CreatedAt)))
+	assert.True(t, expectedTime.Equal(time.Time(*got.Results[0].Version.CreatedAt)))
+
 	assert.Equal(t, "2", got.Results[1].ID)
 	assert.Equal(t, "/wiki/api/v2/folders?cursor=abc123", got.Links.Next)
 }

--- a/pkg/infra/models/confluence_folder_test.go
+++ b/pkg/infra/models/confluence_folder_test.go
@@ -1,0 +1,126 @@
+package models
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFolderScheme_UnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name     string
+		json     string
+		expected FolderScheme
+	}{
+		{
+			name: "full response from API",
+			json: `{
+				"id": "123456",
+				"type": "folder",
+				"status": "current",
+				"title": "My Folder",
+				"parentId": "789",
+				"parentType": "page",
+				"position": 5,
+				"authorId": "author-1",
+				"ownerId": "owner-1",
+				"createdAt": "2024-09-23T20:17:35.607Z",
+				"spaceId": "space-42",
+				"version": {
+					"createdAt": "2024-09-23T20:17:35.607Z",
+					"message": "initial version",
+					"number": 1,
+					"minorEdit": false,
+					"authorId": "author-1"
+				},
+				"_links": {
+					"self": "https://example.atlassian.net/wiki/api/v2/folders/123456"
+				}
+			}`,
+			expected: FolderScheme{
+				ID:         "123456",
+				Type:       "folder",
+				Status:     "current",
+				Title:      "My Folder",
+				ParentID:   "789",
+				ParentType: "page",
+				Position:   5,
+				AuthorID:   "author-1",
+				OwnerID:    "owner-1",
+				CreatedAt:  "2024-09-23T20:17:35.607Z",
+				SpaceID:    "space-42",
+				Version: &FolderVersionScheme{
+					CreatedAt: "2024-09-23T20:17:35.607Z",
+					Message:   "initial version",
+					Number:    1,
+					MinorEdit: false,
+					AuthorID:  "author-1",
+				},
+				Links: &FolderLinksScheme{
+					Self: "https://example.atlassian.net/wiki/api/v2/folders/123456",
+				},
+			},
+		},
+		{
+			name: "minimal response",
+			json: `{
+				"id": "123456",
+				"title": "Minimal Folder",
+				"createdAt": "2025-01-15T10:30:00.000Z"
+			}`,
+			expected: FolderScheme{
+				ID:        "123456",
+				Title:     "Minimal Folder",
+				CreatedAt: "2025-01-15T10:30:00.000Z",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got FolderScheme
+			err := json.Unmarshal([]byte(tt.json), &got)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+func TestFolderChunkScheme_UnmarshalJSON(t *testing.T) {
+	payload := `{
+		"results": [
+			{
+				"id": "1",
+				"title": "Folder A",
+				"createdAt": "2024-06-15T08:00:00.000Z",
+				"version": {
+					"number": 1,
+					"createdAt": "2024-06-15T08:00:00.000Z"
+				}
+			},
+			{
+				"id": "2",
+				"title": "Folder B",
+				"createdAt": "2024-07-20T14:30:00.000Z"
+			}
+		],
+		"_links": {
+			"next": "/wiki/api/v2/folders?cursor=abc123"
+		}
+	}`
+
+	var got FolderChunkScheme
+	err := json.Unmarshal([]byte(payload), &got)
+	require.NoError(t, err)
+
+	assert.Len(t, got.Results, 2)
+	assert.Equal(t, "1", got.Results[0].ID)
+	assert.Equal(t, "Folder A", got.Results[0].Title)
+	assert.Equal(t, "2024-06-15T08:00:00.000Z", got.Results[0].CreatedAt)
+	assert.Equal(t, 1, got.Results[0].Version.Number)
+	assert.Equal(t, "2024-06-15T08:00:00.000Z", got.Results[0].Version.CreatedAt)
+	assert.Equal(t, "2", got.Results[1].ID)
+	assert.Equal(t, "/wiki/api/v2/folders?cursor=abc123", got.Links.Next)
+}

--- a/pkg/infra/models/confluence_time.go
+++ b/pkg/infra/models/confluence_time.go
@@ -1,0 +1,57 @@
+package models
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+)
+
+// ConfluenceDateTimeScheme is a custom time type for Confluence v2 API timestamps.
+//
+// The Confluence v2 API returns timestamps as ISO 8601 strings
+// (e.g. "2024-09-23T20:17:35.607Z"), but some endpoints may return
+// Unix epoch milliseconds as numbers.
+//
+// This type handles both formats during JSON unmarshaling and marshals
+// back to RFC 3339 format.
+type ConfluenceDateTimeScheme time.Time
+
+// MarshalJSON marshals the ConfluenceDateTimeScheme to JSON as an RFC 3339 string.
+func (d *ConfluenceDateTimeScheme) MarshalJSON() ([]byte, error) {
+	return []byte(fmt.Sprintf(`"%s"`, time.Time(*d).Format(time.RFC3339))), nil
+}
+
+// UnmarshalJSON unmarshals the ConfluenceDateTimeScheme from JSON.
+//
+// It accepts:
+//   - RFC 3339 strings with optional fractional seconds (e.g. "2024-09-23T20:17:35.607Z")
+//   - Unix epoch millisecond numbers (e.g. 1727122655607)
+func (d *ConfluenceDateTimeScheme) UnmarshalJSON(data []byte) error {
+	s := string(data)
+
+	if s == "null" {
+		return nil
+	}
+
+	// Quoted string: parse as RFC 3339 (with optional fractional seconds).
+	if len(data) >= 2 && data[0] == '"' {
+		raw := s[1 : len(s)-1]
+
+		parsed, err := time.Parse(time.RFC3339Nano, raw)
+		if err != nil {
+			return fmt.Errorf("cannot parse %q as Confluence timestamp: %w", raw, err)
+		}
+
+		*d = ConfluenceDateTimeScheme(parsed)
+		return nil
+	}
+
+	// Unquoted number: parse as Unix epoch milliseconds.
+	ms, err := strconv.ParseInt(s, 10, 64)
+	if err != nil {
+		return fmt.Errorf("cannot parse %s as Confluence timestamp: %w", s, err)
+	}
+
+	*d = ConfluenceDateTimeScheme(time.UnixMilli(ms))
+	return nil
+}

--- a/pkg/infra/models/confluence_time_test.go
+++ b/pkg/infra/models/confluence_time_test.go
@@ -1,0 +1,102 @@
+package models
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConfluenceDateTimeScheme_UnmarshalJSON(t *testing.T) {
+	type args struct {
+		data []byte
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    ConfluenceDateTimeScheme
+		wantErr assert.ErrorAssertionFunc
+	}{
+		{
+			name:    "null",
+			args:    args{data: []byte(`null`)},
+			want:    ConfluenceDateTimeScheme{},
+			wantErr: assert.NoError,
+		},
+		{
+			name:    "ISO 8601 with milliseconds",
+			args:    args{data: []byte(`"2024-09-23T20:17:35.607Z"`)},
+			want:    ConfluenceDateTimeScheme(time.Date(2024, 9, 23, 20, 17, 35, 607000000, time.UTC)),
+			wantErr: assert.NoError,
+		},
+		{
+			name:    "RFC 3339 without fractional seconds",
+			args:    args{data: []byte(`"2024-09-23T20:17:35Z"`)},
+			want:    ConfluenceDateTimeScheme(time.Date(2024, 9, 23, 20, 17, 35, 0, time.UTC)),
+			wantErr: assert.NoError,
+		},
+		{
+			name:    "RFC 3339 with timezone offset",
+			args:    args{data: []byte(`"2024-09-23T22:17:35+02:00"`)},
+			want:    ConfluenceDateTimeScheme(time.Date(2024, 9, 23, 22, 17, 35, 0, time.FixedZone("", 7200))),
+			wantErr: assert.NoError,
+		},
+		{
+			name:    "Unix epoch milliseconds",
+			args:    args{data: []byte(`1727122655607`)},
+			want:    ConfluenceDateTimeScheme(time.Date(2024, 9, 23, 20, 17, 35, 607000000, time.UTC)),
+			wantErr: assert.NoError,
+		},
+		{
+			name:    "invalid string",
+			args:    args{data: []byte(`"not-a-date"`)},
+			want:    ConfluenceDateTimeScheme{},
+			wantErr: assert.Error,
+		},
+		{
+			name:    "invalid token",
+			args:    args{data: []byte(`true`)},
+			want:    ConfluenceDateTimeScheme{},
+			wantErr: assert.Error,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := ConfluenceDateTimeScheme{}
+			tt.wantErr(t, d.UnmarshalJSON(tt.args.data), fmt.Sprintf("UnmarshalJSON(%s)", tt.args.data))
+			assert.Truef(t, time.Time(tt.want).Equal(time.Time(d)), "expected %v, got %v", time.Time(tt.want), time.Time(d))
+		})
+	}
+}
+
+func TestConfluenceDateTimeScheme_MarshalJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		t       ConfluenceDateTimeScheme
+		want    string
+		wantErr assert.ErrorAssertionFunc
+	}{
+		{
+			name:    "UTC time",
+			t:       ConfluenceDateTimeScheme(time.Date(2024, 9, 23, 20, 17, 35, 0, time.UTC)),
+			want:    `"2024-09-23T20:17:35Z"`,
+			wantErr: assert.NoError,
+		},
+		{
+			name:    "time with offset",
+			t:       ConfluenceDateTimeScheme(time.Date(2024, 9, 23, 22, 17, 35, 0, time.FixedZone("CET", 7200))),
+			want:    `"2024-09-23T22:17:35+02:00"`,
+			wantErr: assert.NoError,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.t.MarshalJSON()
+			if !tt.wantErr(t, err, "MarshalJSON()") {
+				return
+			}
+			assert.Equal(t, tt.want, string(got))
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #447.

- **Add `ConfluenceDateTimeScheme`** — a new `time.Time`-based type that handles both ISO 8601 strings (`"2024-09-23T20:17:35.607Z"`) and Unix epoch millisecond numbers (`1727122655607`) during JSON unmarshaling. Follows the same `type X time.Time` pattern as the existing `DateScheme`/`DateTimeScheme` for Jira.
- **Change `CreatedAt` from `*time.Time` to `*ConfluenceDateTimeScheme`** in `FolderScheme` and `FolderVersionScheme` — fixes `json: cannot unmarshal number into Go struct field .createdAt of type time.Time`.
- **Add missing documented fields**: `FolderScheme.SpaceID`, `FolderVersionScheme.{Message, MinorEdit, AuthorID}` — these are present in the [API response schema](https://developer.atlassian.com/cloud/confluence/rest/v2/api-group-folder/#api-folders-id-get) and in the analogous `PageVersionScheme`.
- **Add comprehensive tests** for both the new time type and JSON unmarshaling of folder structs with realistic API payloads.

### Validation

Verified against the [Confluence v2 Folder API docs](https://developer.atlassian.com/cloud/confluence/rest/v2/api-group-folder/) and live API responses confirming `createdAt` is documented as `string` (date-time). The numeric format is a [known Atlassian API inconsistency](https://community.atlassian.com/forums/Confluence-questions/REST-API-v2-Creating-a-database-returns-createdAt-date-as-number/qaq-p/2819640) affecting some v2 endpoints.

## Test plan

- [x] `go build ./pkg/... ./confluence/... ./service/...` passes
- [x] `go test ./confluence/internal/ -run Folder` — existing connector tests pass
- [x] `go test ./pkg/infra/models/ -run Confluence` — new time type tests pass (ISO 8601 strings, epoch ms, null, invalid input)
- [x] `go test ./pkg/infra/models/ -run Folder` — new unmarshal tests pass (full response, numeric timestamps, minimal response, chunk)